### PR TITLE
small fix with header header formatting, removed remaining mentions of OpenCV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This lesson shows how to use Python and OpenCV to do basic image processing.
+This lesson shows how to use Python and skimage to do basic image processing.

--- a/_episodes/02-image-basics.md
+++ b/_episodes/02-image-basics.md
@@ -560,7 +560,7 @@ the image description and the "artist," were added manually. Depending on how
 you intend to use images, the metadata contained within the images may be 
 important or useful to you. However, care must be taken when using our computer
 vision library, skimage, to write images. We will examine metadata a little 
-more closely in the [skimage Images]({{ page.root }}/03-opencv-images) episode.
+more closely in the [skimage Images]({{ page.root }}/03-skimage-images) episode.
 
 ## Summary of image formats
 

--- a/_episodes/03-skimage-images.md
+++ b/_episodes/03-skimage-images.md
@@ -21,8 +21,8 @@ the blue, i.e. RGB."
 - "Images are read from disk with the `skimage.io.imread()` function."
 - "We create a window that automatically scales the displayed image 
 with `skimage.viewer.ImageViewer()` and calling `view()` on the viewer object."
-- "Color images can be transformed to grayscale using `skimage.color.rgb2gray()`" or
-be read as grayscale directly by passing the argument `as_gray=True` to `skimage.io.imread()`
+- "Color images can be transformed to grayscale using `skimage.color.rgb2gray()` or
+be read as grayscale directly by passing the argument `as_gray=True` to `skimage.io.imread()`."
 - "We can resize images with the `skimage.transform.resize()` function."
 - "NumPy array commands, like `img[img < 128] = 0`, and be used to manipulate
 the pixels of an image."

--- a/_episodes/04-drawing.md
+++ b/_episodes/04-drawing.md
@@ -27,7 +27,7 @@ images based on changes in color or shape.
 
 Often we wish to select only a portion of an image to analyze, and ignore the 
 rest. Creating a rectangular sub-image with slicing, as we did in the 
-[skimage Images]({{ page.root }}/03-opencv-images) lesson is one option for
+[skimage Images]({{ page.root }}/03-skimage-images) lesson is one option for
 simple cases. Another option is to create another special image, of the same 
 size as the original, with white pixels indicating the region to save and
 black pixels everywhere else. Such an image is called a *mask*. In preparing 

--- a/_episodes/10-challenges.md
+++ b/_episodes/10-challenges.md
@@ -30,7 +30,7 @@ each of these images. These images can be found in the
 
 ![Colony image 3](../fig/00-colonies03.jpg)
 
-Write a Python program that uses OpenCV to count the number of bacteria 
+Write a Python program that uses skimage to count the number of bacteria
 colonies in each image, and for each, produce a new image that outlines the 
 colonies, and displays the number of coloines. Your output should be similar to
 this image:
@@ -42,7 +42,7 @@ this image:
 The video showing the titration process first mentioned in the workshop 
 [introduction]({{ page.root }}/01-introduction/) episode can be found in the 
 **Desktop/workshops/image-processing/10-challenges/colorimetric** directory.
-Write a Python program that uses OpenCV to analyze the video on a 
+Write a Python program that uses skimage to analyze the video on a
 frame-by-frame basis. Your program should do the following:
 
 1. Sample a kernel from the same location on each frame, and determine the 


### PR DESCRIPTION
* When looking at the rendered material it seemed that the third episode was not properly rendered. Moving some quotes did the trick.
* corrected links to episode03 (which has been renamed in the process of OpenCV->skimage translation
* removed some more traces of OpenCV
