### PR TITLE
correcting import statement

### DIFF
--- a/code/02-image-basics/ws.py
+++ b/code/02-image-basics/ws.py
@@ -4,7 +4,7 @@
  *
  * usage: python ws.py <dim>
 """
-import skimage
+import skimage.io
 import sys
 import numpy as np
 


### PR DESCRIPTION
This example code uses `import skimage` while all others use `import skimage.io` to match the `skimage.io.foo` function usage style.  No in text code examples are in episode 2 to compare usage, so I think this is either a random bug or possibly due to an older version of the module?  All other code examples use `import skimage.io`. I know there are discussions about import issues, but this runs with an error as it currently stands.