### PR TITLE
adding location details for examples

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -9,6 +9,6 @@ permalink: /setup/
 1. Download and install the latest [Anaconda distribution](https://www.anaconda.com/distribution/) for your operating system.
    Make sure to choose the Python 3 version (as opposed to the one with Python 2).
 
-2. Download and extract the workshop files.
+2. All code and example image files are contained within the [`code`](https://github.com/datacarpentry/image-processing/tree/gh-pages/code) folder of this repository.  Learners can clone the repo or download the full repo zip file to their local computers and access the files that way, or instructors may choose to provide a zip file of just the `code` folder.
    TODO: discuss
 


### PR DESCRIPTION
I'm teaching this for a workshop and it took me a full 20 minutes to read the lesson and figure out where the examples were located in this repo.  The TODO: discuss still remains true, but I thought a direct pointer for where the files are would help those testing the workshop out until a stable download or other directions could be provided.

I'm fine with any wording edits from the maintainers, but my larger point here is to provide info on where things are stored.
