### PR TITLE
correcting k -> sigma

### DIFF
--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -124,7 +124,7 @@ Now is where the main work of the program takes place.
 ~~~
 # blur and grayscale before thresholding
 blur = skimage.color.rgb2gray(image)
-blur = skimage.filters.gaussian(blur, sigma=k)
+blur = skimage.filters.gaussian(blur, sigma=sigma)
 ~~~
 {: .python}
 


### PR DESCRIPTION
The example code and the other examples in the lesson all have `sigma=sigma` but this example says `sigma=k`.  Perhaps this is a leftover piece from writing a function. Changing k->sigma to match the other examples and the variables that exist within the program.