### PR TITLE
correcting t_rescaled -> t

### DIFF
--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -137,7 +137,7 @@ The fixed-level thresholding is performed using numpy comparison operators.
 
 ~~~
 # perform inverse binary thresholding
-mask = blur < t_rescaled
+mask = blur < t
 ~~~
 {: .python}
 


### PR DESCRIPTION
Using incorrect variable that doesn't exist, changing it to `t` to match the example code and the variables created earlier in the program.