### PR TITLE
fixing view() -> show()

### DIFF
--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -162,7 +162,7 @@ sel[mask] = image[mask]
 
 # display the result
 viewer = skimage.viewer.ImageViewer(sel)
-viewer.view()
+viewer.show()
 ~~~
 {: .python}
 


### PR DESCRIPTION
I'm not sure where this came from, but it appears to be a bug? I don't know this package well. All other instances use `viewer.show()` and I get an error with `viewer.view()`.