### PR TITLE
adding example parameters in script doc

### DIFF
--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -89,6 +89,7 @@ accomplish this task.
  * Python script to demonstrate simple thresholding.
  *
  * usage: python Threshold.py <filename> <sigma> <threshold>
+ * Example parameter values: 2 for sigma and .8 for threshold
 """
 import sys
 import numpy as np


### PR DESCRIPTION
I'm not using the command line to execute these scripts, so I need to add values in to run this directly.  The example values for how to run this script aren't specified until much later in the episode.  Possible values are given, but not example ones for testing.  Given that this script is introduced in chunks, it is very natural to want to execute these in chunks, making the need for parameters to be specified well before they are introduced.  Feel free to reject this and add them elsewhere. I thought this might just be the easiest solution for now?