### PR TITLE
fixing bug that grayscaled image not blurred

### DIFF
--- a/code/07-thresholding/AdaptiveThreshold.py
+++ b/code/07-thresholding/AdaptiveThreshold.py
@@ -21,7 +21,7 @@ viewer.show()
 
 # grayscale and blur before thresholding
 blur = skimage.color.rgb2gray(image)
-blur = skimage.filters.gaussian(image, sigma=sigma)
+blur = skimage.filters.gaussian(blur, sigma=sigma)
 
 # perform adaptive thresholding
 t = skimage.filters.thresh_otsu(blur)


### PR DESCRIPTION
Sorry I don't know how to squash PRs in the github website, so there will be a corresponding fix to the lesson copy as well.

This is a bug where the image that is grayscaled is not sent to the blur function. Just needs to be image -> blur.