### PR TITLE
bug that grayscale image now blurred

### DIFF
--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -333,7 +333,7 @@ Next, a blurred grayscale image is created.
 ~~~
 # blur and grayscale before thresholding
 blur = skimage.color.rgb2gray(image)
-blur = skimage.filters.gaussian(image, sigma=sigma)
+blur = skimage.filters.gaussian(blur, sigma=sigma)
 ~~~
 {: .python}
 


### PR DESCRIPTION
Sorry I don't know how to squash PRs in the github website, so there is a corresponding PR for correcting the sample code.

This is a bug where the image that is grayscaled is not sent to the blur function. Just needs to be image -> blur.