### PR TITLE
Correcting root collage image in lesson 7

### DIFF
--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -383,7 +383,7 @@ Let us now turn to an application where we can apply thresholding and other
 techniques we have learned to this point. Consider these four maize root 
 system images.
 
-![Four root images](../fig/06-four-root-collage.png)
+![Four root images](../fig/07-four-maize-roots.jpg)
 
 Now suppose we are interested in the amount of plant material in each image, 
 and in particular how that amount changes from image to image. Perhaps the 


### PR DESCRIPTION
An incorrect image was being used at the beginning of the measuring root mass application. Uploaded the correct image to ../fig; this change updates the markdown to point at the correct image.