### PR TITLE
Fix runtime error in root mass example

### DIFF
--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -486,7 +486,7 @@ block of code determines the root mass ratio in the image:
 
 ~~~
 # determine root mass ratio
-rootPixels = np.nonzero(binary)
+rootPixels = np.count_nonzero(binary)
 w = binary.shape[1]
 h = binary.shape[0]
 density = rootPixels / (w * h)


### PR DESCRIPTION
The rootmass example code has np.nonzero(), which returns a tuple. We need to use np.count_nonzero() instead. This was originally a OpenCV function call, cv.countNonZero().