### PR TITLE
Fix typo: label2rbg -> label2rgb in CCA.py in 09-connected-components

### DIFF
--- a/code/09-connected-components/CCA.py
+++ b/code/09-connected-components/CCA.py
@@ -35,5 +35,5 @@ viewer.show()
 # Perform CCA on the mask
 labeled_image = skimage.measure.label(mask, connectivity=2)
 
-viewer = skimage.viewer.ImageViewer(skimage.color.label2rbg(labeled_image, bg_label=0))
+viewer = skimage.viewer.ImageViewer(skimage.color.label2rgb(labeled_image, bg_label=0))
 viewer.show()


### PR DESCRIPTION
Fixes `AttributeError: module 'skimage.color' has no attribute 'label2rbg'` when displaying the results of CCA on the mask.

This may be obsolete if the viewer is changed as suggested in #99 