### PR TITLE
Code block CSS

### DIFF
--- a/_episodes/02-image-basics.md
+++ b/_episodes/02-image-basics.md
@@ -396,7 +396,7 @@ computing platforms.
 > > > -rw-rw-r--  1 diva diva 75000054 Jun 18 08:51 ws.bmp
 > > >
 > > > -rw-rw-r--  1 diva diva    72986 Jun 18 08:53 ws.zip
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > We can see that the regularity of the bitmap image (remember, it is a 5,000 x 5,000 pixel
 > > image containing only white pixels) allows the lossless compression scheme to compress

--- a/_episodes/03-skimage-images.md
+++ b/_episodes/03-skimage-images.md
@@ -222,7 +222,7 @@ this case, the `.tif` extension causes the image to be saved as a TIFF.
 > > ~~~
 > > python Resize.py
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > The program resizes the **chicago.jpg** image by 50% in both dimensions,
 > > and saves the result in the **resized.jpg** file.
@@ -278,7 +278,7 @@ program form the command line like this:
 ~~~
 python HighIntensity.py roots.jpg
 ~~~
-{: .bash}
+{: .language-bash}
 
 The place where this happens in the code is the
 `skimage.io.imread(fname=sys.argv[1])`

--- a/_episodes/03-skimage-images.md
+++ b/_episodes/03-skimage-images.md
@@ -99,7 +99,7 @@ import skimage.io
 # read image
 image = skimage.io.imread(fname="chair.jpg")
 ~~~
-{: .python}
+{: .language-python}
 
 First, we import the `io` module of skimage (`skimage.io`) so
 we can read and write images. Then, we use the `skimage.io.imread()` function to read
@@ -112,7 +112,7 @@ Next, we will do something with the image:
 ~~~
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 Once we have the image in the program, we next call `skimage.io.imshow()` in order to display the image.
 
@@ -122,7 +122,7 @@ Next, we will save the image in another format:
 # save a new version in .tif format
 skimage.io.imsave(fname="chair.tif", arr=image)
 ~~~
-{: .python}
+{: .language-python}
 
 The final statement in the program, `skimage.io.imsave(fname="chair.tif", arr=image)`,
 writes the image to a file named `chair.tif`. The `imsave()` function automatically
@@ -184,7 +184,7 @@ this case, the `.tif` extension causes the image to be saved as a TIFF.
 > new_shape = (image.shape[0] // 2, image.shape[1] // 2, image.shape[2])
 > small = skimage.transform.resize(image=image, output_shape=new_shape)
 > ~~~
-> {: .python}
+> {: .language-python}
 >
 > As it is used here, the parameters to the `skimage.transform.resize()` function are the
 > image to transform, `image`, the dimensions we want the new image to have.
@@ -215,7 +215,7 @@ this case, the `.tif` extension causes the image to be saved as a TIFF.
 > > # write out image
 > > skimage.io.imsave(fname="resized.jpg", arr=small)
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > >
 > > From the command line, we would execute the program like this:
 > >
@@ -266,7 +266,7 @@ image = skimage.io.imread(fname=sys.argv[1])
 # display original image
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 Our program imports `sys` in addition to `skimage`, so that we can use
 *command-line arguments* when we execute the program. In particular, in this
@@ -304,7 +304,7 @@ image[image < 128] = 0
 # display modified image
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 The NumPy command to ignore all low-intensity pixels is `image[image < 128] = 0`.
 Every pixel color value in the whole 3-dimensional array with a value less
@@ -357,7 +357,7 @@ extraneous background detail has been removed.
 > > # display modified image
 > > skimage.io.imshow(img)
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > {: .solution}
 {: .challenge}
 
@@ -395,7 +395,7 @@ skimage.io.imshow(image)
 gray_image = skimage.color.rgb2gray(image)
 skimage.io.imshow(gray_image)
 ~~~
-{: .python}
+{: .language-python}
 
 We can also load color images as grayscale directly by passing the argument `as_gray=True` to
 `skimage.io.imread()`.
@@ -416,7 +416,7 @@ image = skimage.io.imread(fname=sys.argv[1], as_gray=True)
 # display grayscale image
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 
 ## Access via slicing
@@ -466,7 +466,7 @@ import skimage.io
 image = skimage.io.imread(fname="board.jpg")
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 Then we use array slicing to
 create a new image with our selected area and then display the new image.
@@ -477,7 +477,7 @@ clip = image[60:151, 135:481, :]
 skimage.io.imshow(clip)
 skimage.io.imsave(fname="clip.tif", arr=clip)
 ~~~
-{: .python}
+{: .language-python}
 
 We can also change the values in an image, as shown next.
 
@@ -487,7 +487,7 @@ color = image[330, 90]
 image[60:151, 135:481] = color
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 First, we sample a single pixel's color at a particular location of the
 image, saving it in a variable named `color`, which creates a 1 × 1 × 3 NumPy array with the blue,
@@ -534,7 +534,7 @@ the program:
 > > # WRITE YOUR CODE TO SAVE clip HERE
 > > skimage.io.imsave(fname="clip.jpg", arr=clip)
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/05-creating-histograms.md
+++ b/_episodes/05-creating-histograms.md
@@ -60,7 +60,7 @@ image = skimage.io.imread(fname=sys.argv[1], as_gray=True)
 # display the image
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 In the program, we have a new import from `matplotlib`, to gain access to the
 tools we will use to draw the histogram. The statement
@@ -85,7 +85,7 @@ the function `np.histogram` instead:
 # create the histogram
 histogram, bin_edges = np.histogram(image, bins=256, range=(0, 1))
 ~~~
-{: .python}
+{: .language-python}
 
 The parameter `bins` determines the histogram size, or the number of "bins" to use for
 the histogram. We pass in `256` because we want to see the pixel count for
@@ -118,7 +118,7 @@ plt.xlim([0.0, 1.0])  # <- named arguments do not work here
 plt.plot(bin_edges[0:-1], histogram)  # <- or here
 plt.show()
 ~~~
-{: .python}
+{: .language-python}
 
 
 We create the plot with
@@ -221,7 +221,7 @@ the program produces this histogram:
 > >
 > > plt.show()
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > >
 > > Your histogram of the masked area should look something like this:
 > >
@@ -254,7 +254,7 @@ image = skimage.io.imread(fname=sys.argv[1])
 # display the image
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 We import the needed libraries, read
 the image based on the command-line parameter (in color this time), and then
@@ -284,7 +284,7 @@ plt.ylabel("Pixels")
 
 plt.show()
 ~~~
-{: .python}
+{: .language-python}
 
 
 We will draw the histogram line for
@@ -325,7 +325,7 @@ of the lists, and so on.
 > for x in zip(list1, list2):
 >     print(x)
 > ~~~
-> {: .python}
+> {: .language-python}
 >
 > Executing this program would produce the following output:
 >
@@ -458,7 +458,7 @@ Finally we label our axes and display the histogram, shown here:
 > >
 > > plt.show()
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/06-blurring.md
+++ b/_episodes/06-blurring.md
@@ -190,7 +190,7 @@ import sys
 filename = sys.argv[1]
 sigma = float(sys.argv[2])
 ~~~
-{: .python}
+{: .language-python}
 
 In this case, the
 program takes two command-line parameters. The first is the filename of the
@@ -250,7 +250,7 @@ the floating point number equivalent.
 > > value = float(sys.argv[1])
 > > print("Your command-line argument is:", value)
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > >
 > > Executing this program with the three command-line arguments suggested
 > > above produces this output:
@@ -283,7 +283,7 @@ also be very familiar to you at this point.
 image = skimage.io.imread(fname=filename)
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 Now we apply the average blur:
 
@@ -292,7 +292,7 @@ Now we apply the average blur:
 blurred = skimage.filters.gaussian(
     image, sigma=(sigma, sigma), truncate=3.5, multichannel=True)
 ~~~
-{: .python}
+{: .language-python}
 
 The first two parameters to `skimage.filters.gaussian()` are the image to blur,
 `image`, and a tuple defining the sigma to use in y- and x-direction,
@@ -312,7 +312,7 @@ displaying the blurred image in a new window.
 # display blurred image
 skimage.io.imshow(blurred)
 ~~~
-{: .python}
+{: .language-python}
 
 Here is a constructed image to use as the input for the preceding program.
 
@@ -398,7 +398,7 @@ applying a filter with a sigma of 3.0.
 > > # display blurred image
 > > skimage.io.imshow(blurred)
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/06-blurring.md
+++ b/_episodes/06-blurring.md
@@ -228,7 +228,7 @@ the floating point number equivalent.
 > python float_arg.py puppy
 > python float_arg.py 13
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > What does `float()` do if it receives a string that cannot be parsed into an
 > integer?
@@ -333,7 +333,7 @@ applying a filter with a sigma of 3.0.
 > ~~~
 > python GaussBlur.py GaussianTarget.png 1.0
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Remember that the first command-line argument is the name of the file to
 > filter, and the second is the sigma value. Now, experiment with the sigma
@@ -364,7 +364,7 @@ applying a filter with a sigma of 3.0.
 > ~~~
 > python GaussBlur.py GaussianTarget.png 1.0 2.0
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Using the program like this utilizes a Gaussian with a sigma of 1.0 in y-
 > direction and 2.0 in x-direction for blurring

--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -106,7 +106,7 @@ t = float(sys.argv[3])
 image = skimage.io.imread(fname=filename)
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 This program takes three command-line arguments: the filename of the image to 
 manipulate, the sigma of the Gaussian used during the blurring step (which, if you recall
@@ -125,7 +125,7 @@ Now is where the main work of the program takes place.
 blur = skimage.color.rgb2gray(image)
 blur = skimage.filters.gaussian(blur, sigma=sigma)
 ~~~
-{: .python}
+{: .language-python}
 
 First, we convert the
 image to grayscale and then blur it, using the `skimage.filter.gaussian()` function we
@@ -138,7 +138,7 @@ The fixed-level thresholding is performed using numpy comparison operators.
 # perform inverse binary thresholding
 mask = blur < t
 ~~~
-{: .python}
+{: .language-python}
 
 Here, we want to turn "on" all pixels which have values smaller than the threshold, 
 so we use the `less operator <` to compare the blurred image `blur` to the threshold `t`.
@@ -162,7 +162,7 @@ sel[mask] = image[mask]
 # display the result
 skimage.io.imshow(sel)
 ~~~
-{: .python}
+{: .language-python}
 
 What we are left with is only the
 colored shapes from the original, as shown in this image:
@@ -251,7 +251,7 @@ colored shapes from the original, as shown in this image:
 > > # display the result
 > > skimage.io.imshow(sel)
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > > 
 > > Using a Gaussian with sigma = 2 and threshold t = 0.5, we obtain this mask:
 > > 
@@ -316,7 +316,7 @@ sigma = float(sys.argv[2])
 image = skimage.io.imread(fname=filename)
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 The program begins with the now-familiar imports and command line parameters. 
 Here we only have to get the filename and the sigma of the Gaussian kernel from the command
@@ -330,7 +330,7 @@ Next, a blurred grayscale image is created.
 blur = skimage.color.rgb2gray(image)
 blur = skimage.filters.gaussian(blur, sigma=sigma)
 ~~~
-{: .python}
+{: .language-python}
 
 We determine the threshold via the `skimage.filters.threshold_otsu()` function:
 
@@ -339,7 +339,7 @@ We determine the threshold via the `skimage.filters.threshold_otsu()` function:
 t = skimage.filters.threshold_otsu(blur)
 mask = blur > t
 ~~~
-{: .python}
+{: .language-python}
 
 The function `skimage.filters.threshold_otsu()` uses Otsu's method to automatically
 determine the threshold value based on its inputs grayscale histogram and returns it.
@@ -363,7 +363,7 @@ sel[mask] = image[mask]
 # display the result
 skimage.io.imshow(sel)
 ~~~
-{: .python}
+{: .language-python}
 
 Here is the result:
 
@@ -426,7 +426,7 @@ sigma = float(sys.argv[2])
 # read the original image, converting to grayscale
 img = skimage.io.imread(fname=filename, as_gray=True)
 ~~~
-{: .python}
+{: .language-python}
 
 The program begins with the usual imports and reading of command-line 
 parameters. Then, we read the original image, based on the filename parameter,
@@ -438,7 +438,7 @@ Next the grayscale image is blurred with a Gaussian that is defined by the sigma
 # blur before thresholding
 blur = skimage.filters.gaussian(img, sigma=sigma)
 ~~~
-{: .python}
+{: .language-python}
 
 Following that, we create a binary image with Otsu's method for 
 thresholding, just as we did in the previous section. Since the program is 
@@ -450,7 +450,7 @@ not display any of the images.
 t = skimage.filters.threshold_otsu(blur)
 binary = blur > t
 ~~~
-{: .python}
+{: .language-python}
 
 We do, however, want to save the binary images, in case we wish to examine them
 at a later time. That is what this block of code does:
@@ -460,7 +460,7 @@ dot = filename.index(".")
 binary_file_name = filename[:dot] + "-binary" + filename[dot:]
 skimage.io.imsave(fname=binary_file_name, arr=skimage.img_as_ubyte(binary))
 ~~~
-{: .python}
+{: .language-python}
 
 This code does a little bit of string manipulation to determine the filename 
 to use when the binary image is saved. For example, if the input filename being
@@ -486,7 +486,7 @@ density = rootPixels / (w * h)
 # output in format suitable for .csv
 print(filename, density, sep=",")
 ~~~
-{: .python}
+{: .language-python}
 
 Recall that we are working with a binary image at this point; every pixel in 
 the image is either zero (black) or 1 (white). We want to count the number
@@ -668,7 +668,7 @@ bash rootmass.sh > rootmass.csv
 > > # output in format suitable for .csv
 > > print(filename, density, sep=",")
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > > 
 > > Here are the binary images produced by this program. We have not completely 
 > > removed the offending white pixels. Outlines still remain. However, we have

--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -503,7 +503,7 @@ we would execute the program this way:
 ~~~ 
 python RootMass.py trial-016.jpg 1.5
 ~~~
-{: .bash}
+{: .language-bash}
 
 and the output we would see would be this:
 
@@ -534,7 +534,7 @@ do
 	python RootMass.py $f 1.5
 done
 ~~~
-{: .bash}
+{: .language-bash}
 
 The script begins by deleting any prior versions of the binary images. After
 that, the script uses a `for` loop to iterate through all of the input images,
@@ -557,7 +557,7 @@ shell script is named **rootmass.sh**, this would do the trick:
 ~~~
 bash rootmass.sh > rootmass.csv
 ~~~
-{: .bash}
+{: .language-bash}
 
 > ## Ignoring more of the images -- brainstorming (10 min - optional, not included in timing)
 > 

--- a/_episodes/08-connected-components.md
+++ b/_episodes/08-connected-components.md
@@ -214,7 +214,7 @@ labeled_image, count = skimage.measure.label(mask, connectivity=2, return_num=Tr
 
 skimage.io.imshow(labeled_image)
 ~~~
-{: .python}
+{: .language-python}
 
 <!-- Note: junk image: with sigma=2.0, threshold=0.9 -> 11 objects; with sigma=5 -> 8 objects -->
 
@@ -250,7 +250,7 @@ print("dtype:", labeled_image.dtype)
 print("min:", np.min(labeled_image))
 print("max:", np.max(labeled_image))
 ~~~
-{: .python}
+{: .language-python}
 
 Examining the output can give us a clue:
 
@@ -281,7 +281,7 @@ colored_labeled_image = skimage.color.label2rgb(labeled_image, bg_label=0)
 # show the created image in the viewer
 skimage.io.imshow(colored_label_image)
 ~~~
-{: .python}
+{: .language-python}
 
 
 > ## How many objects are in that image (15 min)
@@ -308,7 +308,7 @@ skimage.io.imshow(colored_label_image)
 > > num_objects = np.max(labeled_image)
 > > print("Found", num_objects, "objects in the image.")
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > >
 > > Invoking the program with `sigma=2.0`, and `threshold=0.9` will print
 > > ~~~
@@ -355,7 +355,7 @@ skimage.io.imshow(colored_label_image)
 > > plt.hist(object_areas)
 > > plt.show()
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > {: .solution}
 {: .challenge}
 
@@ -386,7 +386,7 @@ skimage.io.imshow(colored_label_image)
 > >     if objf["area"] < 10000:
 > >         labeled_image[labeled_image == object_id] = 0
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > {: .solution}
 >
 > Lastly print out the count for the large objects
@@ -402,7 +402,7 @@ skimage.io.imshow(colored_label_image)
 > >
 > > print("Found", len(filtered_list), "objects!")
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > >
 > > The script, if working properly, will produce the following output:
 > >

--- a/_extras/edge-detection.md
+++ b/_extras/edge-detection.md
@@ -133,7 +133,7 @@ sigma = float(sys.argv[2])
 low_threshold = float(sys.argv[3])
 high_threshold = float(sys.argv[4])
 ~~~
-{: .python}
+{: .language-python}
 
 Next, the original images is read, in grayscale, and displayed.
 
@@ -142,7 +142,7 @@ Next, the original images is read, in grayscale, and displayed.
 image = skimage.io.imread(fname=filename, as_gray=True)
 skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 Then, we apply Canny edge detection with this function call:
 
@@ -154,7 +154,7 @@ edges = skimage.feature.canny(
     high_threshold=high_threshold,
 )
 ~~~
-{: .python}
+{: .language-python}
 
 As we are using it here, the `skimage.feature.canny()` function takes four parameters.
 The first parameter is the input image. The `sigma` parameter determines the
@@ -172,7 +172,7 @@ found in the original.
 # display edges
 skimage.io.imshow(edges)
 ~~~
-{: .python}
+{: .language-python}
 
 Here is the result, for the colored shape image above,
 with sigma value 2.0, low threshold value 0.1 and high threshold value 0.3:
@@ -251,7 +251,7 @@ filename = sys.argv[1]
 image = skimage.io.imread(fname=filename, as_gray=True)
 viewer = skimage.io.imshow(image)
 ~~~
-{: .python}
+{: .language-python}
 
 The `skimage.viewer.plugins.Plugin` class is designed to manipulate images.
 It takes an `image_filter` argument in the constructor that should be a function.
@@ -281,7 +281,7 @@ canny_plugin += skimage.viewer.widgets.Slider(
     name="high_threshold", low=0.0, high=1.0, value=0.2
 )
 ~~~
-{: .python}
+{: .language-python}
 
 A slider is a widget that lets you choose a number by dragging a handle along a line.
 On the left side of the line, we have the lowest value, on the right side the highest value that can be chosen.
@@ -305,7 +305,7 @@ Finally, we add the plugin the viewer and display the resulting user interface:
 viewer += canny_plugin
 viewer.show()
 ~~~
-{: .python}
+{: .language-python}
 
 Here is the result of running the preceding program on the beads image, with a sigma value 1.0,
 low threshold value 0.1 and high threshold value 0.3. The image
@@ -395,7 +395,7 @@ shows the edges in an output file.
 > > viewer += smooth_threshold_plugin
 > > viewer.show()
 > > ~~~
-> > {: .python}
+> > {: .language-python}
 > >
 > > Here is the output of the program, blurring with a sigma of 1.5 and a
 > > threshold value of 0.45:


### PR DESCRIPTION
The lesson is using the old names for the CSS classes used to apply syntax highlighting to code blocks in the lesson template. This PR updates the class names to reapply syntax highlighting. 