### PR TITLE
Similar to PR #111

### DIFF
--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -572,7 +572,7 @@ bash rootmass.sh > rootmass.csv
 > Let us take a closer look at the binary images produced by the 
 > proceeding program. 
 > 
-> ![Binary root images](../fig/06-four-root-binary-collage.png)
+> ![Binary root images](../fig/07-four-maize-roots-binary.jpg)
 > 
 > Our root mass ratios include white pixels that are not
 > part of the plant in the image, do they not? The numbered labels and the 

--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -570,7 +570,7 @@ bash rootmass.sh > rootmass.csv
 > ## Ignoring more of the images -- brainstorming (10 min)
 > 
 > Let us take a closer look at the binary images produced by the 
-> proceeding program. 
+> preceding program. 
 > 
 > ![Binary root images](../fig/07-four-maize-roots-binary.jpg)
 > 


### PR DESCRIPTION
Introductory image for "Ignoring more of the images" challenge also needs to be updated. The image itself has already been committed, this PR fixes the markdown to point to the correct image.