### PR TITLE
Expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-This lesson shows how to use Python and skimage to do basic image processing.
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
+[![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--image--processing-E01563.svg)](https://swcarpentry.slack.com/archives/C027H977ZGU)
+
+# Image Processing with Python
+
+A lesson teaching foundational image processing skills with Python and [scikit-image](https://scikit-image.org/).
+
+**The lesson is currently under active development and should not be considered stable.** We are aiming for a beta release to the Data Carpentry community before the end of 2021.
+
+## Lesson Content
+
+This lesson introduces fundamental concepts in image handling and processing. Learners will gain the skills needed to load images into Python, to select, summarise, and modify specific regions in these image, and to identify and extract objects within an image for further analysis.
+
+The lesson assumes a working knowledge of Python and some previous exposure to the Bash shell.
+A detailed list of prerequisites can be found in [`_extras/prereqs.md`](_extras/prereqs.md).
+
+Image Processing with Python is planned for release as an official [Data Carpentry](https://datacarpentry.org/) curriculum in 2022.
+
+## Contribution
+
+- Make a suggestion or correct an error by [raising an Issue](https://github.com/datacarpentry/image-processing/issues).
+
+## Code of Conduct
+
+All participants should agree to abide by the [The Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).
+
+## Lesson Developers
+
+The Image Processing with Python lesson is currently being developed by:
+
+* [Kimberly Meechan](https://github.com/K-Meech)
+* [David Palmquist](https://github.com/quist00)
+* [Ulf Schiller](https://github.com/uschille)
+* [Robert Turner](https://github.com/bobturneruk)
+* [Erin Becker](https://github.com/ErinBecker)
+* [Toby Hodges](https://github.com/tobyhodges)
+
+They are building on previous work by [Mark Meysenburg](https://github.com/mmeysenburg), [Tessa Durham Brooks](https://github.com/tessalea), [Dominik Kutra](https://github.com/k-dominik) and [Constantin Pape](https://github.com/constantinpape).


### PR DESCRIPTION
Fixes #149, expanding the README.md to make the repository more accessible to new contributors/community members interested in the current state of the lesson.

Includes:

- link to Slack channel
- brief overview of lesson content
- links to issues listing and Code of Conduct
- list of current and past developers, which can be updated to a list of Maintainers to accompany the beta release.