### PR TITLE
Enable Jekyll build on Windows 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ vendor/
 .docker-vendor/
 Gemfile.lock
 .*history
+.vscode/*

--- a/_config.yml
+++ b/_config.yml
@@ -94,6 +94,7 @@ exclude:
   - .Rproj.user/
   - .vendor/
   - .docker-vendor/
+  - vendor
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge


### PR DESCRIPTION
I was unable to build the site (roughly) following these instructions https://carpentries.github.io/lesson-example/setup.html. I got the following error:

```
(base) PS C:\Users\bobturner\Documents\image-processing> bundle exec jekyll serve
Configuration file: C:/Users/bobturner/Documents/image-processing/_config.yml
            Source: C:/Users/bobturner/Documents/image-processing
       Destination: C:/Users/bobturner/Documents/image-processing/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
      Remote Theme: Using theme carpentries/carpentries-theme
             Error: could not read file C:/Users/bobturner/Documents/image-processing/vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb: Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```

Following these instructions https://github.com/jekyll/jekyll/issues/5267 I was able to fix.

This PR also adds vscode settings to gitignore to facilitate using vscode for editing files.