### PR TITLE
08-connected-components: Fix image path for last three figures

### DIFF
--- a/_episodes/08-connected-components.md
+++ b/_episodes/08-connected-components.md
@@ -481,7 +481,7 @@ This will produce the output
 > > ~~~
 > > {: .language-python}
 > >
-> > ![Histogram of object areas](../../fig/08-areas-histogram.png)
+> > ![Histogram of object areas](../fig/08-areas-histogram.png)
 > >
 > > The histogram shows the number of objects (vertical axis) whose
 > > area is within a certain range (horizontal axis). The height of
@@ -670,7 +670,7 @@ This will produce the output
 > > ~~~
 > > {: .language-python}
 > >
-> > ![Objects filtered by area](../../fig/08-filtered-objects.png)
+> > ![Objects filtered by area](../fig/08-filtered-objects.png)
 > >
 > > ~~~
 > > Found 7 objects in the image.
@@ -714,6 +714,6 @@ This will produce the output
 > > ~~~
 > > {: .language-python}
 > >
-> > ![Objects colored by area](../../fig/08-objects-colored-by-area.png)
+> > ![Objects colored by area](../fig/08-objects-colored-by-area.png)
 > {: .solution}
 {: .challenge}


### PR DESCRIPTION
Fixes #168. Some images were included with a wrong relative path which slipped through the local tests because `../../` is the local working directory where `fig/` is found alongside `_site`.