### PR TITLE
Fix some blockquote/code block style declarations

### DIFF
--- a/_episodes/02-image-basics.md
+++ b/_episodes/02-image-basics.md
@@ -598,14 +598,13 @@ computing platforms.
 > >
 > > Here is a partial directory listing, showing the sizes of the relevant files there:
 > >
-> > > -rw-rw-r--  1 diva diva   154344 Jun 18 08:32 tree.jpg
-> > >
-> > > -rw-rw-r--  1 diva diva   146049 Jun 18 08:53 tree.zip
-> > >
-> > > -rw-rw-r--  1 diva diva 75000054 Jun 18 08:51 ws.bmp
-> > >
-> > > -rw-rw-r--  1 diva diva    72986 Jun 18 08:53 ws.zip
-> > {: .language-bash}
+> > ~~~
+> > -rw-rw-r--  1 diva diva   154344 Jun 18 08:32 tree.jpg
+> > -rw-rw-r--  1 diva diva   146049 Jun 18 08:53 tree.zip
+> > -rw-rw-r--  1 diva diva 75000054 Jun 18 08:51 ws.bmp
+> > -rw-rw-r--  1 diva diva    72986 Jun 18 08:53 ws.zip
+> > ~~~
+> > {: .output}
 > >
 > > We can see that the regularity of the bitmap image (remember, it is a 5,000 x 5,000 pixel
 > > image containing only white pixels) allows the lossless compression scheme to compress

--- a/_episodes/05-creating-histograms.md
+++ b/_episodes/05-creating-histograms.md
@@ -307,15 +307,13 @@ of the lists, and so on.
 >
 > Executing this program would produce the following output:
 >
-> > (1, 'a')
-> >
-> > (2, 'b')
-> >
-> > (3, 'c')
-> >
-> > (4, 'd')
-> >
-> > (5, 'e')
+> ~~~
+> (1, 'a')
+> (2, 'b')
+> (3, 'c')
+> (4, 'd')
+> (5, 'e')
+> ~~~
 > {: .output}
 {: .callout}
 

--- a/_extras/edge-detection.md
+++ b/_extras/edge-detection.md
@@ -262,6 +262,7 @@ This function should produce a new image as an output, given an image as the fir
 canny_plugin = skimage.viewer.plugins.Plugin(image_filter=skimage.feature.canny)
 canny_plugin.name = "Canny Filter Plugin"
 ~~~
+{: .language-python}
 
 We want to interactively modify the parameters of the filter function interactively.
 Skimage allows us to further enrich the plugin by adding widgets, like `skimage.viewer.widgets.Slider`, `skimage.viewer.widgets.CheckBox`, `skimage.viewer.widgets.ComboBox`.


### PR DESCRIPTION
This pull request fixes some minor blockquote/code block declarations that would cause `make lesson-check` to throw warnings.