### PR TITLE
Add PNG details to table

### DIFF
--- a/_episodes/02-image-basics.md
+++ b/_episodes/02-image-basics.md
@@ -766,5 +766,6 @@ image formats:
 |          |               |            | high quality          |                    |
 | JPEG     | Lossy         | Yes        | Universally viewable, | Detail may be lost |
 |          |               |            | smaller file size     |                    |
+| PNG      | Lossless      | [Yes](https://www.w3.org/TR/PNG/#11keywords) | Universally viewable, [open standard](https://www.w3.org/TR/PNG/), smaller file size | Metadata less flexible than TIFF, RGB only |
 | TIFF     | None, lossy,  | Yes        | High quality or       | Not universally viewable   |
 |          | or lossless   |            | smaller file size     |                    |


### PR DESCRIPTION
Resolves #194

I've tried to do this with minimal changes. It could be argued that PNG supports lossless compression, but you'd need to reduce the size of the image before saving it (e.g. reducing bit depth makes lossless compression work better) - I think this is a nuance we can avoid. The statement about metadata being less flexible than TIFF is also arguable - I suspect one could hack and extend PNG to shove a bunch of json into a keyword field (https://www.w3.org/TR/PNG/#11keywords). Again, for our purposes, this discussion is best avoided.