### PR TITLE
Fix deprecation warning

### DIFF
--- a/_episodes/06-blurring.md
+++ b/_episodes/06-blurring.md
@@ -252,7 +252,7 @@ sigma = 3.0
 
 # apply Gaussian blur, creating a new image
 blurred = skimage.filters.gaussian(
-    image, sigma=(sigma, sigma), truncate=3.5, multichannel=True)
+    image, sigma=(sigma, sigma), truncate=3.5, channel_axis=2)
 ~~~
 {: .language-python}
 


### PR DESCRIPTION
Code at line 254 of ep 6 (`scikit-image  0.19.2`) gives:

```
FutureWarning: `multichannel` is a deprecated argument name for `gaussian`. It will be removed in version 1.0. Please use `channel_axis` instead.
```

This PR resolves this by following the suggested course of action.