### PR TITLE
Remove redundant code

### DIFF
--- a/_episodes/04-drawing.md
+++ b/_episodes/04-drawing.md
@@ -70,7 +70,6 @@ image = skimage.io.imread(fname="data/maize-seedlings.tif")
 
 fig, ax = plt.subplots()
 plt.imshow(image)
-plt.show()
 ~~~
 {: .language-python}
 
@@ -118,7 +117,6 @@ mask[rr, cc] = False
 # Display mask image
 fig, ax = plt.subplots()
 plt.imshow(mask, cmap="gray")
-plt.show()
 ~~~
 {: .language-python}
 
@@ -362,7 +360,6 @@ Then, we display the masked image.
 ~~~
 fig, ax = plt.subplots()
 plt.imshow(image)
-plt.show()
 ~~~
 {: .language-python}
 

--- a/_episodes/04-drawing.md
+++ b/_episodes/04-drawing.md
@@ -217,7 +217,6 @@ The function returns the rectangle as row (`rr`) and column (`cc`) coordinate ar
 > > # Display the image
 > > fig, ax = plt.subplots()
 > > plt.imshow(image)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -248,7 +247,6 @@ The function returns the rectangle as row (`rr`) and column (`cc`) coordinate ar
 > > # display the results
 > > fig, ax = plt.subplots()
 > > plt.imshow(image)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -298,7 +296,6 @@ The function returns the rectangle as row (`rr`) and column (`cc`) coordinate ar
 > > # display the results
 > > fig, ax = plt.subplots()
 > > plt.imshow(image)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > {: .solution}
@@ -405,7 +402,6 @@ The resulting masked image should look like this:
 > > # Display the result
 > > fig, ax = plt.subplots()
 > > plt.imshow(image)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > {: .solution}
@@ -422,7 +418,6 @@ The resulting masked image should look like this:
 > # Display the image
 > fig, ax = plt.subplots()
 > plt.imshow(image)
-> plt.show()
 > ~~~
 > {: .language-python}
 >
@@ -469,7 +464,6 @@ The resulting masked image should look like this:
 > > # display the result
 > > fig, ax = plt.subplots()
 > > plt.imshow(image)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -538,7 +532,6 @@ The resulting masked image should look like this:
 > > # display the result
 > > fig, ax = plt.subplots()
 > > plt.imshow(image)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > {: .solution}

--- a/_episodes/05-creating-histograms.md
+++ b/_episodes/05-creating-histograms.md
@@ -122,7 +122,6 @@ plt.ylabel("pixel count")
 plt.xlim([0.0, 1.0])  # <- named arguments do not work here
 
 plt.plot(bin_edges[0:-1], histogram)  # <- or here
-plt.show()
 ~~~
 {: .language-python}
 
@@ -201,7 +200,6 @@ it produces this histogram:
 > > # display the image
 > > fig, ax = plt.subplots()
 > > plt.imshow(image, cmap="gray")
-> > plt.show()
 > >
 > > # create mask here, using np.zeros() and skimage.draw.rectangle()
 > > mask = np.zeros(shape=image.shape, dtype="bool")
@@ -211,7 +209,6 @@ it produces this histogram:
 > > # display the mask
 > > fig, ax = plt.subplots()
 > > plt.imshow(mask, cmap="gray")
-> > plt.show()
 > >
 > > # mask the image and create the new histogram
 > > histogram, bin_edges = np.histogram(image[mask], bins=256, range=(0.0, 1.0))
@@ -225,7 +222,6 @@ it produces this histogram:
 > > plt.xlim([0.0, 1.0])
 > > plt.plot(bin_edges[0:-1], histogram)
 > >
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -280,8 +276,6 @@ for channel_id, c in zip(channel_ids, colors):
 plt.title("Color Histogram")
 plt.xlabel("Color value")
 plt.ylabel("Pixel count")
-
-plt.show()
 ~~~
 {: .language-python}
 
@@ -379,7 +373,6 @@ Finally we label our axes and display the histogram, shown here:
 > # display the image
 > fig, ax = plt.subplots()
 > plt.imshow(image)
-> plt.show()
 > ~~~
 > {: .language-python}
 > ![Well plate image](../fig/wellplate-02.jpg)
@@ -420,7 +413,6 @@ Finally we label our axes and display the histogram, shown here:
 > > # validity of your mask
 > > fig, ax = plt.subplots()
 > > plt.imshow(masked_img)
-> > plt.show()
 > >
 > > # list to select colors of each channel line
 > > colors = ("red", "green", "blue")
@@ -442,7 +434,6 @@ Finally we label our axes and display the histogram, shown here:
 > > plt.xlabel("color value")
 > > plt.ylabel("pixel count")
 > >
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > {: .solution}

--- a/_episodes/05-creating-histograms.md
+++ b/_episodes/05-creating-histograms.md
@@ -57,7 +57,6 @@ image = skimage.io.imread(fname="data/plant-seedling.jpg", as_gray=True)
 # display the image
 fig, ax = plt.subplots()
 plt.imshow(image, cmap="gray")
-plt.show()
 ~~~
 {: .language-python}
 
@@ -252,7 +251,6 @@ image = skimage.io.imread(fname="data/plant-seedling.jpg")
 # display the image
 fig, ax = plt.subplots()
 plt.imshow(image)
-plt.show()
 ~~~
 {: .language-python}
 

--- a/_episodes/05-creating-histograms.md
+++ b/_episodes/05-creating-histograms.md
@@ -149,7 +149,6 @@ Finally, we create the histogram plot itself with
 We use the **left** bin edges as x-positions for the histogram values by
 indexing the `bin_edges` array to ignore the last value
 (the **right** edge of the last bin).
-Then we make it appear with `plt.show()`.
 When we run the program on this image of a plant seedling,
 it produces this histogram:
 

--- a/_episodes/06-blurring.md
+++ b/_episodes/06-blurring.md
@@ -241,7 +241,6 @@ image = skimage.io.imread(fname="data/gaussian-original.png")
 # display the image
 fig, ax = plt.subplots()
 plt.imshow(image)
-plt.show()
 ~~~
 {: .language-python}
 ![Original image](../data/gaussian-original.png)
@@ -279,7 +278,6 @@ Finally, we display the blurred image:
 # display blurred image
 fig, ax = plt.subplots()
 plt.imshow(blurred)
-plt.show()
 ~~~
 {: .language-python}
 ![Original image](../fig/gaussian-blurred.png)

--- a/_episodes/06-blurring.md
+++ b/_episodes/06-blurring.md
@@ -323,7 +323,6 @@ plt.imshow(blurred)
 > > # display blurred image
 > > fig, ax = plt.subplots()
 > > plt.imshow(blurred)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >

--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -65,7 +65,6 @@ image = skimage.io.imread("data/shapes-01.jpg")
 
 fig, ax = plt.subplots()
 plt.imshow(image)
-plt.show()
 ~~~
 {: .language-python}
 
@@ -95,7 +94,6 @@ blurred_image = skimage.filters.gaussian(gray_image, sigma=1.0)
 
 fig, ax = plt.subplots()
 plt.imshow(blurred_image, cmap="gray")
-plt.show()
 ~~~
 {: .language-python}
 
@@ -163,7 +161,6 @@ binary_mask = blurred_image < t
 
 fig, ax = plt.subplots()
 plt.imshow(binary_mask, cmap="gray")
-plt.show()
 ~~~
 {: .language-python}
 
@@ -208,7 +205,6 @@ selection[~binary_mask] = 0
 
 fig, ax = plt.subplots()
 plt.imshow(selection)
-plt.show()
 ~~~
 {: .language-python}
 
@@ -318,7 +314,6 @@ image = skimage.io.imread(fname="data/maize-root-cluster.jpg")
 
 fig, ax = plt.subplots()
 plt.imshow(image)
-plt.show()
 ~~~
 {: .language-python}
 
@@ -386,7 +381,6 @@ binary_mask = blurred_image > t
 
 fig, ax = plt.subplots()
 plt.imshow(binary_mask, cmap="gray")
-plt.show()
 ~~~
 {: .language-python}
 
@@ -401,7 +395,6 @@ selection[~binary_mask] = 0
 
 fig, ax = plt.subplots()
 plt.imshow(selection)
-plt.show()
 ~~~
 {: .language-python}
 

--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -126,7 +126,6 @@ plt.title("Grayscale Histogram")
 plt.xlabel("grayscale value")
 plt.ylabel("pixels")
 plt.xlim(0, 1.0)
-plt.show()
 ~~~
 {: .language-python}
 
@@ -236,7 +235,6 @@ plt.imshow(selection)
 > > plt.xlabel("gray value")
 > > plt.ylabel("pixel count")
 > > plt.xlim(0, 1.0)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -265,7 +263,6 @@ plt.imshow(selection)
 > >
 > > fig, ax = plt.subplots()
 > > plt.imshow(binary_mask, cmap="gray")
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -279,7 +276,6 @@ plt.imshow(selection)
 > >
 > > fig, ax = plt.subplots()
 > > plt.imshow(selection)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -337,7 +333,6 @@ plt.title("Graylevel histogram")
 plt.xlabel("gray value")
 plt.ylabel("pixel count")
 plt.xlim(0, 1.0)
-plt.show()
 ~~~
 {: .language-python}
 
@@ -696,7 +691,6 @@ data/trial-293.jpg,0.13607895611702128
 > > plt.xlabel("gray value")
 > > plt.ylabel("pixel count")
 > > plt.xlim(0, 1.0)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -717,7 +711,6 @@ data/trial-293.jpg,0.13607895611702128
 > >
 > > fig, ax = plt.subplots()
 > > plt.imshow(binary_mask, cmap="gray")
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >

--- a/_episodes/08-connected-components.md
+++ b/_episodes/08-connected-components.md
@@ -297,8 +297,7 @@ labeled_image, count = connected_components(filename="data/shapes-01.jpg", sigma
 
 fig, ax = plt.subplots()
 plt.imshow(labeled_image)
-plt.axis("off")
-plt.show()
+plt.axis("off");
 ~~~
 {: .language-python}
 
@@ -357,8 +356,7 @@ colored_label_image = skimage.color.label2rgb(labeled_image, bg_label=0)
 
 fig, ax = plt.subplots()
 plt.imshow(colored_label_image)
-plt.axis("off")
-plt.show()
+plt.axis("off");
 ~~~
 {: .language-python}
 
@@ -499,8 +497,7 @@ This will produce the output
 > > fig, ax = plt.subplots()
 > > plt.hist(object_areas)
 > > plt.xlabel("Area (pixels)")
-> > plt.ylabel("Number of objects")
-> > plt.show()
+> > plt.ylabel("Number of objects");
 > > ~~~
 > > {: .language-python}
 > >
@@ -690,8 +687,7 @@ This will produce the output
 > >
 > > fig, ax = plt.subplots()
 > > plt.imshow(colored_label_image)
-> > plt.axis("off")
-> > plt.show()
+> > plt.axis("off");
 > >
 > > print("Found", count, "objects in the image.")
 > > ~~~
@@ -736,8 +732,7 @@ This will produce the output
 > > im = plt.imshow(colored_area_image)
 > > cbar = fig.colorbar(im, ax=ax, shrink=0.85)
 > > cbar.ax.set_title("Area")
-> > plt.axis("off")
-> > plt.show()
+> > plt.axis("off");
 > > ~~~
 > > {: .language-python}
 > >

--- a/_episodes/09-challenges.md
+++ b/_episodes/09-challenges.md
@@ -68,7 +68,6 @@ and `data/colonies-03.tif`.
 > > # display the image
 > > fig, ax = plt.subplots()
 > > plt.imshow(bacteria_image)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -84,7 +83,6 @@ and `data/colonies-03.tif`.
 > > # display the gray image
 > > fig, ax = plt.subplots()
 > > plt.imshow(gray_bacteria, cmap="gray")
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -101,7 +99,6 @@ and `data/colonies-03.tif`.
 > > plt.xlabel("gray value")
 > > plt.ylabel("pixel count")
 > > plt.xlim(0, 1.0)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -117,7 +114,6 @@ and `data/colonies-03.tif`.
 > > mask = blurred_image < 0.2
 > > fig, ax = plt.subplots()
 > > plt.imshow(mask, cmap="gray")
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >
@@ -146,7 +142,6 @@ and `data/colonies-03.tif`.
 > > # plot overlay
 > > fig, ax = plt.subplots()
 > > plt.imshow(summary_image)
-> > plt.show()
 > > ~~~
 > > {: .language-python}
 > >

--- a/setup.md
+++ b/setup.md
@@ -85,7 +85,6 @@ e.g. your Desktop or a folder you have created for using in this workshop.
    # display the image
    fig, ax = plt.subplots()
    plt.imshow(image, cmap='gray')
-   plt.show()
    ~~~
    {: .language-python}
    Upon execution of the cell, an image should be displayed in an interactive widget. When hovering over the image with the mouse pointer, the pixel coordinates and color values are displayed below the image.


### PR DESCRIPTION
I don't think these statements are needed. There is slightly different behaviour if `plt.show()` is invoked after `plt.imshow(...)` but we're inconsistent in current version and tend not to include `plt.show()`. Best code is no code!