### PR TITLE
Fix call to img_as_ubyte

### DIFF
--- a/_episodes/03-skimage-images.md
+++ b/_episodes/03-skimage-images.md
@@ -153,7 +153,7 @@ In this case, the `.tif` extension causes the image to be saved as a TIFF.
 > ~~~
 > new_shape = (image.shape[0] // 10, image.shape[1] // 10, image.shape[2])
 > small = skimage.transform.resize(image=image, output_shape=new_shape)
-> small = skimage.img_as_ubyte(small)
+> small = skimage.util.img_as_ubyte(small)
 > ~~~
 > {: .language-python}
 >
@@ -165,7 +165,7 @@ In this case, the `.tif` extension causes the image to be saved as a TIFF.
 > Image files on disk are normally stored as whole numbers for space efficiency,
 > but transformations and other math operations often result in
 > conversion to floating point numbers.
-> Using the `skimage.img_as_ubyte()` method converts it back to whole numbers
+> Using the `skimage.util.img_as_ubyte()` method converts it back to whole numbers
 > before we save it back to disk.
 > If we don't convert it before saving,
 > `skimage.io.imsave()` will do so regardless and generate a
@@ -202,7 +202,7 @@ In this case, the `.tif` extension causes the image to be saved as a TIFF.
 > > # resize the image
 > > new_shape = (image.shape[0] // 10, image.shape[1] // 10, image.shape[2])
 > > small = skimage.transform.resize(image=image, output_shape=new_shape)
-> > small = skimage.img_as_ubyte(small)
+> > small = skimage.util.img_as_ubyte(small)
 > >
 > > # write out image
 > > skimage.io.imsave(fname="data/resized.jpg", arr=small)

--- a/_episodes/03-skimage-images.md
+++ b/_episodes/03-skimage-images.md
@@ -145,7 +145,7 @@ In this case, the `.tif` extension causes the image to be saved as a TIFF.
 
 > ## Resizing an image (10 min)
 >
-> Add `import skimage.transform` to your list of imports.
+> Add `import skimage.transform` and `import skimage.util` to your list of imports.
 > Using chair.jpg image located in the data folder,
 > write a Python script to read your image into a variable named `image`.
 > Then, resize the image to 10 percent of its current size using these lines of code:


### PR DESCRIPTION
The function `img_as_ubyte` needs to be called as `skimage.util.img_as_ubyte`. The `util` part was sometimes missing.
