### PR TITLE
Move details about mode argument earlier in the lesson.

### DIFF
--- a/_episodes/03-skimage-images.md
+++ b/_episodes/03-skimage-images.md
@@ -360,6 +360,15 @@ plt.imshow(image, cmap="gray")
 ~~~
 {: .language-python}
 
+The first argument to `iio.imread()` is the filename of the image.
+The second argument `mode="L"` defines the type and depth of a pixel in the
+image (e.g., an 8-bit pixel has a range of 0-255). This argument is forwarded
+to the `pillow` backend, for which mode "L" means 8-bit pixels and
+single-channel (i.e., grayscale). `pillow` is a Python imaging library; which
+backend is used by `iio.imread()` may be specified (to use `pillow`, you would
+pass this argument: `plugin="pillow"`); if unspecified, `iio.imread()`
+determines the backend to use based on the image type.
+
 > ## Keeping only low intensity pixels (10 min)
 >
 > A little earlier, we showed how we could use Python and skimage to turn

--- a/_episodes/05-creating-histograms.md
+++ b/_episodes/05-creating-histograms.md
@@ -67,15 +67,6 @@ plt.imshow(image, cmap="gray")
 ![Plant seedling](../fig/plant-seedling-grayscale.png)
 
 Again, we use the `iio.imread()` function to load our image.
-The first argument to `iio.imread()` is the filename of the image.
-The second argument `mode="L"` defines the type and depth of a pixel in the
-image (e.g., an 8-bit pixel has a range of 0-255). This argument is forwarded
-to the `pillow` backend, for which mode "L" means 8-bit pixels and
-single-channel (i.e., grayscale). `pillow` is a Python imaging library; which
-backend is used by `iio.imread()` may be specified (to use `pillow`, you would
-pass this argument: `plugin="pillow"`); if unspecified, `iio.imread()`
-determines the backend to use based on the image type.
-
 Then, we convert the grayscale image of integer dtype, with 0-255 range, into
 a floating-point one with 0-1 range, by calling the function
 `skimage.util.img_as_float`.


### PR DESCRIPTION
This minor PR follows from #249 but it does not fix it. It just makes more sense to discuss the `mode="L"` argument of `iio.imread()` on the first time it is introduced.