### PR TITLE
changing away from image as variable name

### DIFF
--- a/_episodes/02-image-basics.md
+++ b/_episodes/02-image-basics.md
@@ -196,8 +196,8 @@ natively (think of volumes, movies).
 {: .callout}
 
 ~~~
-image = iio.imread(uri="data/eight.tif")
-plt.imshow(image)
+eight_tiff = iio.imread(uri="data/eight.tif")
+plt.imshow(eight_tiff)
 ~~~
 {: .language-python}
 
@@ -226,8 +226,8 @@ and see the matrix by printing our image variable to the screen.
 
 
 ~~~
-print(image.shape)
-print(image)
+print(eight_tiff.shape)
+print(eight_tiff)
 ~~~
 {: .language-python}
 

--- a/_episodes/03-skimage-images.md
+++ b/_episodes/03-skimage-images.md
@@ -49,7 +49,7 @@ Here are the first few lines:
 import imageio.v3 as iio
 
 # read image
-image = iio.imread(uri="data/chair.jpg")
+chair_jpg = iio.imread(uri="data/chair.jpg")
 ~~~
 {: .language-python}
 
@@ -65,7 +65,7 @@ Next, we will do something with the image:
 import matplotlib.pyplot as plt
 
 fig, ax = plt.subplots()
-plt.imshow(image)
+plt.imshow(chair_jpg)
 ~~~
 {: .language-python}
 
@@ -78,11 +78,11 @@ Now, we will save the image in another format:
 
 ~~~
 # save a new version in .tif format
-iio.imwrite(uri="data/chair.tif", image=image)
+iio.imwrite(uri="data/chair.tif", image=chair_jpg)
 ~~~
 {: .language-python}
 
-The final statement in the program, `iio.imwrite(uri="data/chair.tif", image=image)`,
+The final statement in the program, `iio.imwrite(uri="data/chair.tif", image=chair_jpg)`,
 writes the image to a file named `chair.tif` in the `data/` directory.
 The `imwrite()` function automatically determines the type of the file,
 based on the file extension we provide.
@@ -142,19 +142,19 @@ In this case, the `.tif` extension causes the image to be saved as a TIFF.
 >
 > Add `import skimage.transform` and `import skimage.util` to your list of imports.
 > Using the `chair.jpg` image located in the data folder,
-> write a Python script to read your image into a variable named `image`.
+> write a Python script to read your image into a variable named `chair_jpg`.
 > Then, resize the image to 10 percent of its current size using these lines of code:
 >
 > ~~~
-> new_shape = (image.shape[0] // 10, image.shape[1] // 10, image.shape[2])
-> small = skimage.transform.resize(image=image, output_shape=new_shape)
+> new_shape = (chair_jpg.shape[0] // 10, chair_jpg.shape[1] // 10, chair_jpg.shape[2])
+> small = skimage.transform.resize(image=chair_jpg, output_shape=new_shape)
 > small = skimage.util.img_as_ubyte(small)
 > ~~~
 > {: .language-python}
 >
 > As it is used here,
 > the parameters to the `skimage.transform.resize()` function are
-> the image to transform, `image`,
+> the image to transform, `chair_jpg`,
 > the dimensions we want the new image to have, `new_shape`.
 >
 > > Note that the pixel values in the new image are an approximation of
@@ -203,11 +203,11 @@ In this case, the `.tif` extension causes the image to be saved as a TIFF.
 > > import skimage.util
 > >
 > > # read in image
-> > image = iio.imread(uri="data/chair.jpg")
+> > chair_jpg = iio.imread(uri="data/chair.jpg")
 > >
 > > # resize the image
-> > new_shape = (image.shape[0] // 10, image.shape[1] // 10, image.shape[2])
-> > small = skimage.transform.resize(image=image, output_shape=new_shape)
+> > new_shape = (chair_jpg.shape[0] // 10, chair_jpg.shape[1] // 10, chair_jpg.shape[2])
+> > small = skimage.transform.resize(image=chair_jpg, output_shape=new_shape)
 > > small = skimage.util.img_as_ubyte(small)
 > >
 > > # write out image
@@ -215,7 +215,7 @@ In this case, the `.tif` extension causes the image to be saved as a TIFF.
 > >
 > > # display images
 > > fig, ax = plt.subplots()
-> > plt.imshow(image)
+> > plt.imshow(chair_jpg)
 > > fig, ax = plt.subplots()
 > > plt.imshow(small)
 > > ~~~
@@ -261,11 +261,11 @@ We will start by reading the image and displaying it.
 import imageio.v3 as iio
 
 # read input image
-image = iio.imread(uri="data/maize-root-cluster.jpg")
+roots = iio.imread(uri="data/maize-root-cluster.jpg")
 
 # display original image
 fig, ax = plt.subplots()
-plt.imshow(image)
+plt.imshow(roots)
 ~~~
 {: .language-python}
 
@@ -274,15 +274,15 @@ Now we can threshold the image and display the result.
 
 ~~~
 # keep only high-intensity pixels
-image[image < 128] = 0
+roots[roots < 128] = 0
 
 # display modified image
 fig, ax = plt.subplots()
-plt.imshow(image)
+plt.imshow(roots)
 ~~~
 {: .language-python}
 
-The NumPy command to ignore all low-intensity pixels is `image[image < 128] = 0`.
+The NumPy command to ignore all low-intensity pixels is `roots[roots < 128] = 0`.
 Every pixel colour value in the whole 3-dimensional array with a value less
 that 128 is set to zero.
 In this case,
@@ -327,14 +327,14 @@ import imageio.v3 as iio
 import skimage.color
 
 # read input image
-image = iio.imread(uri="data/chair.jpg")
+chair_jpg = iio.imread(uri="data/chair.jpg")
 
 # display original image
 fig, ax = plt.subplots()
-plt.imshow(image)
+plt.imshow(chair_jpg)
 
 # convert to grayscale and display
-gray_image = skimage.color.rgb2gray(image)
+gray_image = skimage.color.rgb2gray(chair_jpg)
 fig, ax = plt.subplots()
 plt.imshow(gray_image, cmap="gray")
 ~~~
@@ -352,11 +352,11 @@ import imageio.v3 as iio
 import skimage.color
 
 # read input image, based on filename parameter
-image = iio.imread(uri="data/chair.jpg", mode="L")
+chair_jpg_l = iio.imread(uri="data/chair.jpg", mode="L")
 
 # display grayscale image
 fig, ax = plt.subplots()
-plt.imshow(image, cmap="gray")
+plt.imshow(chair_jpg_l, cmap="gray")
 ~~~
 {: .language-python}
 
@@ -396,14 +396,14 @@ determines the backend to use based on the image type.
 > > ~~~
 > > import imageio.v3
 > >
-> > image = iio.imread(uri="data/sudoku.jpg", mode="L")
+> > sodoku = iio.imread(uri="data/sudoku.jpg", mode="L")
 > > ~~~
 > > {: .language-python }
 > >
 > > Then, change all high intensity pixel values (> 0.75) to 0.75:
 > >
 > > ~~~
-> > image[image > 0.75] = 0.75
+> > sodoku[sodoku > 0.75] = 0.75
 > > ~~~
 > > {: .language-python }
 > >
@@ -411,7 +411,7 @@ determines the backend to use based on the image type.
 > >
 > > ~~~
 > > fig, ax = plt.subplots()
-> > plt.imshow(image, cmap="gray", vmin=0, vmax=1)
+> > plt.imshow(sodoku, cmap="gray", vmin=0, vmax=1)
 > > ~~~
 > > {: .language-python}
 > {: .solution}
@@ -489,9 +489,9 @@ A script to create the subimage would start by loading the image:
 import imageio.v3 as iio
 
 # load and display original image
-image = iio.imread(uri="data/board.jpg")
+board = iio.imread(uri="data/board.jpg")
 fig, ax = plt.subplots()
-plt.imshow(image)
+plt.imshow(board)
 ~~~
 {: .language-python}
 
@@ -500,7 +500,7 @@ create a new image with our selected area and then display the new image.
 
 ~~~
 # extract, display, and save sub-image
-clip = image[60:151, 135:481, :]
+clip = board[60:151, 135:481, :]
 fig, ax = plt.subplots()
 plt.imshow(clip)
 iio.imwrite(uri="data/clip.tif", image=clip)
@@ -511,10 +511,10 @@ We can also change the values in an image, as shown next.
 
 ~~~
 # replace clipped area with sampled color
-color = image[330, 90]
-image[60:151, 135:481] = color
+color = board[330, 90]
+board[60:151, 135:481] = color
 fig, ax = plt.subplots()
-plt.imshow(image)
+plt.imshow(board)
 ~~~
 {: .language-python}
 
@@ -552,13 +552,13 @@ as shown in the final image produced by the program:
 > > import imageio.v3 as iio
 > >
 > > # load and display original image
-> > image = iio.imread(uri="data/maize-root-cluster.jpg")
+> > root = iio.imread(uri="data/maize-root-cluster.jpg")
 > > fig, ax = plt.subplots()
-> > plt.imshow(image)
+> > plt.imshow(root)
 > >
 > > # extract, display, and save sub-image
 > > # WRITE YOUR CODE TO SELECT THE SUBIMAGE NAME clip HERE:
-> > clip = image[0:400, 275:550, :]
+> > clip = root[0:400, 275:550, :]
 > > fig, ax = plt.subplots()
 > > plt.imshow(clip)
 > >

--- a/_episodes/03-skimage-images.md
+++ b/_episodes/03-skimage-images.md
@@ -273,6 +273,8 @@ plt.imshow(roots)
 Now we can threshold the image and display the result.
 
 ~~~
+# copy the image so it can be manipulated
+roots = roots.copy()
 # keep only high-intensity pixels
 roots[roots < 128] = 0
 
@@ -396,14 +398,15 @@ determines the backend to use based on the image type.
 > > ~~~
 > > import imageio.v3
 > >
-> > sodoku = iio.imread(uri="data/sudoku.jpg", mode="L")
+> > sodoku = iio.imread(uri="data/sudoku.png")
 > > ~~~
 > > {: .language-python }
 > >
 > > Then, change all high intensity pixel values (> 0.75) to 0.75:
 > >
 > > ~~~
-> > sodoku[sodoku > 0.75] = 0.75
+> > sodoku = sodoku.copy()
+> > sodoku[sodoku > 125] = 125
 > > ~~~
 > > {: .language-python }
 > >
@@ -511,6 +514,7 @@ We can also change the values in an image, as shown next.
 
 ~~~
 # replace clipped area with sampled color
+board = board.copy()
 color = board[330, 90]
 board[60:151, 135:481] = color
 fig, ax = plt.subplots()


### PR DESCRIPTION
This PR changes places in episides 2 and 3 where the image variable name was image. Additionally, it corrects for refering to the sodoku image as a jpg although it is a png, and uses picture.copy() after creating certain images so they can be properly accessed (without this the accessing can create :ValueError: assignment destination is read-only) 