### PR TITLE
Move (nearly) all imports to the beginning of episodes

### DIFF
--- a/_episodes/02-image-basics.md
+++ b/_episodes/02-image-basics.md
@@ -841,9 +841,6 @@ JPEG images can be viewed and manipulated easily on all computing platforms.
 > and then saves it as a BMP and as a JPEG image.
 >
 > ~~~
-> import imageio.v3 as iio
-> import numpy as np
->
 > dim = 5000
 >
 > img = np.zeros((dim, dim, 3), dtype="uint8")

--- a/_episodes/02-image-basics.md
+++ b/_episodes/02-image-basics.md
@@ -103,6 +103,9 @@ import skimage
 ~~~
 {: .language-python}
 
+The `v3` module of imageio (`imageio.v3`) is imported as `iio`. This module
+enables us to read and write images.
+
 > ## Import Statements in Python
 >
 > In Python, the `import` statement is used to

--- a/_episodes/03-skimage-images.md
+++ b/_episodes/03-skimage-images.md
@@ -37,6 +37,8 @@ import ipympl
 import imageio.v3 as iio
 import skimage
 import skimage.color
+import skimage.transform
+import skimage.util
 ~~~
 {: .language-python}
 
@@ -203,8 +205,6 @@ In this case, the `.tif` extension causes the image to be saved as a TIFF.
 > >  * Python script to read an image, resize it, and save it
 > >  * under a different name.
 > > """
-> > import skimage.transform
-> > import skimage.util
 > >
 > > # read in image
 > > image = iio.imread(uri="data/chair.jpg")

--- a/_episodes/03-skimage-images.md
+++ b/_episodes/03-skimage-images.md
@@ -203,8 +203,6 @@ In this case, the `.tif` extension causes the image to be saved as a TIFF.
 > >  * Python script to read an image, resize it, and save it
 > >  * under a different name.
 > > """
-> > import imageio.v3 as iio
-> > import matplotlib.pyplot as plt
 > > import skimage.transform
 > > import skimage.util
 > >
@@ -402,7 +400,6 @@ pass `plugin="pillow"`. If the backend is not specified explicitly, `iio.imread(
 > > First, load the image file `data/sudoku.png` as a grayscale image. Remember that we use `image = np.array(image)` to create a copy of the image array because `imageio` returns a non-writeable image.
 > >
 > > ~~~
-> > import imageio.v3 as iio
 > >
 > > image = iio.imread(uri="data/sudoku.png", mode="L")
 > > image = np.array(image)
@@ -556,7 +553,6 @@ as shown in the final image produced by the program:
 > >  * Python script to extract a sub-image containing only the plant and
 > >  * roots in an existing image.
 > > """
-> > import imageio.v3 as iio
 > >
 > > # load and display original image
 > > image = iio.imread(uri="data/maize-root-cluster.jpg")

--- a/_episodes/03-skimage-images.md
+++ b/_episodes/03-skimage-images.md
@@ -28,6 +28,18 @@ images, e.g., `clip = image[60:150, 135:480, :]`."
 We have covered much of how images are represented in computer software. In this episode we will learn some more methods
  for accessing and changing digital images.
 
+## First, import the packages needed for this episode
+
+~~~
+import numpy as np
+import matplotlib.pyplot as plt
+import ipympl
+import imageio.v3 as iio
+import skimage
+import skimage.color
+~~~
+{: .language-python}
+
 ## Reading, displaying, and saving images
 
 Imageio provides intuitive functions for reading and writing (saving) images.
@@ -46,24 +58,18 @@ Here are the first few lines:
  * Python program to open, display, and save an image.
  *
 """
-import imageio.v3 as iio
-
 # read image
 image = iio.imread(uri="data/chair.jpg")
 ~~~
 {: .language-python}
 
-First, we import the `v3` module of imageio (`imageio.v3`) as `iio` so
-we can read and write images.
-Then, we use the `iio.imread()` function to read a JPEG image entitled **chair.jpg**.
+We use the `iio.imread()` function to read a JPEG image entitled **chair.jpg**.
 Imageio reads the image, converts it from JPEG into a NumPy array,
 and returns the array; we save the array in a variable named `image`.
 
 Next, we will do something with the image:
 
 ~~~
-import matplotlib.pyplot as plt
-
 fig, ax = plt.subplots()
 plt.imshow(image)
 ~~~
@@ -263,7 +269,6 @@ When loading an image with `imageio`, in certain situations the image is stored 
 * Python script to ignore low intensity pixels in an image.
 *
 """
-import imageio.v3 as iio
 
 # read input image
 image = iio.imread(uri="data/maize-root-cluster.jpg")
@@ -329,8 +334,6 @@ because using floating point numbers is numerically more stable.
 * Python script to load a color image as grayscale.
 *
 """
-import imageio.v3 as iio
-import skimage.color
 
 # read input image
 image = iio.imread(uri="data/chair.jpg")
@@ -354,8 +357,6 @@ passing the argument `mode="L"` to `iio.imread()`.
 * Python script to load a color image as grayscale.
 *
 """
-import imageio.v3 as iio
-import skimage.color
 
 # read input image, based on filename parameter
 image = iio.imread(uri="data/chair.jpg", mode="L")
@@ -493,7 +494,6 @@ A script to create the subimage would start by loading the image:
  * Python script demonstrating image modification and creation via
  * NumPy array slicing.
 """
-import imageio.v3 as iio
 
 # load and display original image
 image = iio.imread(uri="data/board.jpg")

--- a/_episodes/04-drawing.md
+++ b/_episodes/04-drawing.md
@@ -32,9 +32,13 @@ import matplotlib.pyplot as plt
 import ipympl
 import imageio.v3 as iio
 import skimage
+import skimage.draw
 %matplotlib widget
 ~~~
 {: .language-python}
+
+Here, we import the `draw` submodule of `skimage` as well as packages familiar
+from earlier in the lesson.
 
 ## Drawing on images
 
@@ -79,10 +83,6 @@ plt.imshow(image)
 ~~~
 {: .language-python}
 
-As before, we first import the `v3` submodule of `imageio` (`imageio.v3`).
-We also import the NumPy library, which we need to create the initial mask
-image.
-Then, we import the `draw` submodule of `skimage`.
 We load and display the initial image in the same way we have done before.
 
 NumPy allows indexing of images/arrays with "boolean" arrays of the same size.

--- a/_episodes/04-drawing.md
+++ b/_episodes/04-drawing.md
@@ -24,6 +24,18 @@ With these tools,
 we will be able to create programs to perform simple analyses of images
 based on changes in colour or shape.
 
+## First, import the packages needed for this episode
+
+~~~
+import numpy as np
+import matplotlib.pyplot as plt
+import ipympl
+import imageio.v3 as iio
+import skimage
+%matplotlib widget
+~~~
+{: .language-python}
+
 ## Drawing on images
 
 Often we wish to select only a portion of an image to analyze,
@@ -59,12 +71,6 @@ start with a now-familiar section of code to open and display the original
 image:
 
 ~~~
-import imageio.v3 as iio
-import skimage.draw
-import numpy as np
-import matplotlib.pyplot as plt
-%matplotlib widget
-
 # Load and display the original image
 image = iio.imread(uri="data/maize-seedlings.tif")
 

--- a/_episodes/05-creating-histograms.md
+++ b/_episodes/05-creating-histograms.md
@@ -22,6 +22,19 @@ argument to the `iio.imread()` function."
 In this episode, we will learn how to use skimage functions to create and
 display histograms for images.
 
+## First, import the packages needed for this episode
+
+~~~
+import numpy as np
+import matplotlib.pyplot as plt
+import ipympl
+import imageio.v3 as iio
+import skimage
+import skimage.draw
+%matplotlib widget
+~~~
+{: .language-python}
+
 ## Introduction to Histograms
 
 As it pertains to images, a *histogram* is a graphical representation showing
@@ -45,13 +58,6 @@ We will use this image of a plant seedling as an example:
 Here we load the image in grayscale instead of full colour, and display it:
 
 ~~~
-import imageio.v3 as iio
-import numpy as np
-import skimage.color
-import skimage.util
-import matplotlib.pyplot as plt
-%matplotlib widget
-
 # read the image of a plant seedling as grayscale from the outset
 image = iio.imread(uri="data/plant-seedling.jpg", mode="L")
 
@@ -185,7 +191,6 @@ it produces this histogram:
 >
 > > ## Solution
 > > ~~~
-> > import skimage.draw
 > >
 > > # read the image as grayscale from the outset
 > > image = iio.imread(uri="data/plant-seedling.jpg", mode="L")

--- a/_episodes/06-blurring.md
+++ b/_episodes/06-blurring.md
@@ -247,13 +247,21 @@ skimage has built-in functions to perform blurring for us, so we do not have to
 perform all of these mathematical operations ourselves. Let's work through
 an example of blurring an image with the skimage Gaussian blur function.
 
-First, we load the image, and display it:
+First, import the packages needed for this episode
+
 ~~~
-import imageio.v3 as iio
+import numpy as np
 import matplotlib.pyplot as plt
+import ipympl
+import imageio.v3 as iio
+import skimage
 import skimage.filters
 %matplotlib widget
+~~~
+{: .language-python}
 
+Then, we load the image, and display it:
+~~~
 image = iio.imread(uri="data/gaussian-original.png")
 
 # display the image

--- a/_episodes/06-blurring.md
+++ b/_episodes/06-blurring.md
@@ -250,7 +250,6 @@ an example of blurring an image with the skimage Gaussian blur function.
 First, import the packages needed for this episode
 
 ~~~
-import numpy as np
 import matplotlib.pyplot as plt
 import ipympl
 import imageio.v3 as iio

--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -46,10 +46,7 @@ In this episode, we will learn how to use skimage functions to perform threshold
 Then, we will use the masks returned by these functions to
 select the parts of an image we are interested in.
 
-## Simple thresholding
-
-Consider the image `data/shapes-01.jpg` with a series of
-crudely cut shapes set against a white background.
+## First, import the packages needed for this episode
 
 ~~~
 import numpy as np
@@ -59,7 +56,15 @@ import imageio.v3 as iio
 import skimage.color
 import skimage.filters
 %matplotlib widget
+~~~
+{: .language-python}
 
+## Simple thresholding
+
+Consider the image `data/shapes-01.jpg` with a series of
+crudely cut shapes set against a white background.
+
+~~~
 # load the image
 image = iio.imread(uri="data/shapes-01.jpg")
 

--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -52,6 +52,7 @@ select the parts of an image we are interested in.
 import numpy as np
 import glob
 import matplotlib.pyplot as plt
+import ipympl
 import imageio.v3 as iio
 import skimage.color
 import skimage.filters

--- a/_episodes/08-connected-components.md
+++ b/_episodes/08-connected-components.md
@@ -209,7 +209,8 @@ the connected component analysis produces a new _labeled_ image with integer pix
 Pixels with the same value, belong to the same object.
 Skimage provides connected component analysis in the function `skimage.measure.label()`.
 Let us add this function to the already familiar steps of thresholding an image.
-Here we define a reusable Python function `connected_components`:
+
+First, import the packages needed for this episode
 
 ~~~
 import numpy as np
@@ -218,7 +219,16 @@ import imageio.v3 as iio
 import skimage.color
 import skimage.filters
 import skimage.measure
+%matplotlib widget
+~~~
+{: .language-python}
 
+Note the new import of `skimage.measure` in order to use the
+`skimage.measure.label` function that performs the CCA.
+
+Next, we define a reusable Python function `connected_components`:
+
+~~~
 def connected_components(filename, sigma=1.0, t=0.5, connectivity=2):
     # load the image
     image = iio.imread(filename)
@@ -235,8 +245,6 @@ def connected_components(filename, sigma=1.0, t=0.5, connectivity=2):
 ~~~
 {: .language-python}
 
-Note the new import of `skimage.measure` in order to use the
-`skimage.measure.label` function that performs the CCA.
 The first four lines of code are familiar from
 [the _Thresholding_ episode]({{ page.root }}{% link _episodes/07-thresholding.md %}).
 

--- a/_episodes/08-connected-components.md
+++ b/_episodes/08-connected-components.md
@@ -215,6 +215,7 @@ First, import the packages needed for this episode
 ~~~
 import numpy as np
 import matplotlib.pyplot as plt
+import ipympl
 import imageio.v3 as iio
 import skimage.color
 import skimage.filters

--- a/_episodes/09-challenges.md
+++ b/_episodes/09-challenges.md
@@ -61,6 +61,7 @@ and `data/colonies-03.tif`.
 > > import skimage.color
 > > import skimage.filters
 > > import matplotlib.pyplot as plt
+> > import ipympl
 > > %matplotlib widget
 > >
 > > bacteria_image = iio.imread(uri="data/colonies-01.tif")


### PR DESCRIPTION
Hi!

This resolves #196 in one way - by putting all of the imports not part of an exercise at the top of each episode - I'm keen to know how people feel about it.

I've done a reasonable job of checking that the import lists are correct by [extracting the code](https://gist.github.com/bobturneruk/dfccd3d6ce5af7545c4a1159ce4724e8) and running it / running `autoflake` on it.

In terms of whether it's good practise to put all imports in a cell at the top of a notebook - this depends entirely on the complexity of the notebook at what it's for, as does the choice of whether to code in a notebook or not. My view is that, here, we're using notebooks more as a teaching tool than we're advocating notebooks as an image analysis tool, so it becomes a matter of convenience. Opinions will vary!