### PR TITLE
Copy image using np.array(image) to avoid read-only error

### DIFF
--- a/_episodes/04-drawing.md
+++ b/_episodes/04-drawing.md
@@ -390,6 +390,7 @@ The resulting masked image should look like this:
 > > ~~~
 > > # Load the image
 > > image = iio.imread(uri="data/remote-control.jpg")
+> > image = np.array(image)
 > >
 > > # Create the basic mask
 > > mask = np.ones(shape=image.shape[0:2], dtype="bool")
@@ -444,6 +445,7 @@ The resulting masked image should look like this:
 > > ~~~
 > > # read in original image
 > > image = iio.imread(uri="data/wellplate-01.jpg")
+> > image = np.array(image)
 > >
 > > # create the mask image
 > > mask = np.ones(shape=image.shape[0:2], dtype="bool")
@@ -500,6 +502,7 @@ The resulting masked image should look like this:
 > > ~~~
 > > # read in original image
 > > image = iio.imread(uri="data/wellplate-01.jpg")
+> > image = np.array(image)
 > >
 > > # create the mask image
 > > mask = np.ones(shape=image.shape[0:2], dtype="bool")

--- a/_episodes/05-creating-histograms.md
+++ b/_episodes/05-creating-histograms.md
@@ -395,7 +395,7 @@ Finally we label our axes and display the histogram, shown here:
 > > # just for display:
 > > # make a copy of the image, call it masked_image, and
 > > # use np.logical_not() and indexing to apply the mask to it
-> > masked_img = image[:]
+> > masked_img = np.array(image)
 > > masked_img[np.logical_not(mask)] = 0
 > >
 > > # create a new figure and display masked_img, to verify the


### PR DESCRIPTION
This is a follow-up to https://github.com/datacarpentry/image-processing/issues/247, where `image = np.array(image)` is suggested as a quick fix to the recent read-only errors with arrays read by imageio. 

Since a recent upgrade in pillow, `iio.imread()` often returns a read-only array, which must be made into a copy in order to edit the image. Whether or not it returns a read-only array seems to depend on the file format (e.g. JPG returns read-only; TIFF returns an editable array probably because it calls tiffile instead of pillow).

I have added the `image = np.array(image)` fix to a couple of code blocks that were missing it and currently produce read-only errors:
- 04-drawing.md solution code for exercises "Masking an image of your own", "Masking a 96-well plate image", and "Masking a 96-well plate image, take two"
- 05-creating-histograms.md around line 398 currently says that `image[:]` also creates a copy, but from my testing this is not the case (it works with lists, but not np.arrays). I have replaced `image[:]` with `image = np.array(image)` to be truthful to the comments and consistent with the rest of the lessons, even though that code runs fine without the copy.

Note: I have only added this fix in places where it would currently error (i.e. if the loaded image is a JPG). There are other locations where it is not necessary to copy the image array because the loaded image is a TIF, and that might be confusing to learners.
