### PR TITLE
[workbench transition] update outdated link anchor

### DIFF
--- a/_episodes/02-image-basics.md
+++ b/_episodes/02-image-basics.md
@@ -979,7 +979,7 @@ where it was captured,
 what type of camera was used and with what settings, etc.
 We normally don't see this metadata when we view an image,
 but we can view it independently if we wish to
-(see [_Accessing Metadata_](#viewing-metadata), below).
+(see [_Accessing Metadata_](#accessing-metadata), below).
 The important thing to be aware of at this stage is that
 you cannot rely on the metadata of an image being fully preserved
 when you use software to process that image.


### PR DESCRIPTION
During the transition to the workbench, I noticed an outdated link anchor and thought it would be good to fix it for you. See https://github.com/carpentries/lesson-transition/issues/46