### PR TITLE
Update use skimage.filters.gaussian for newer versions of scikit-image

### DIFF
--- a/_episodes/06-blurring.md
+++ b/_episodes/06-blurring.md
@@ -342,7 +342,7 @@ plt.imshow(blurred)
 > > ~~~
 > > # apply Gaussian blur, with a sigma of 1.0 in the ry direction, and 6.0 in the cx direction
 > > blurred = skimage.filters.gaussian(
-> >     image, sigma=(1.0, 6.0), truncate=3.5, multichannel=True
+> >     image, sigma=(1.0, 6.0), truncate=3.5, channel_axis=-1
 > > )
 > >
 > > # display blurred image


### PR DESCRIPTION
This PR updates the use of `skimage.filters.gaussian` for newer version scikit-image.

From scikit-image docs:
> Automatic detection of the color channel based on the old deprecated multichannel=None was broken in version 0.19. In 0.20 this behavior is fixed. The last axis of an image with dimensions (M, N, 3) is interpreted as a color channel if channel_axis is not set by the user (signaled by the default proxy value ChannelAxisNotSet). Starting with 0.21, channel_axis=None will be used as the new default value.