### PR TITLE
Avoid the word "easily" as things might not be easy for learners

### DIFF
--- a/_episodes/07-thresholding.md
+++ b/_episodes/07-thresholding.md
@@ -561,7 +561,7 @@ data/trial-293.jpg,0.13607895611702128
 > > the area containing the white circle and the numbered label.
 > > If we had coordinates for a rectangular area on the image
 > > that contained the circle and the label,
-> > we could mask the area out easily by using techniques we learned in
+> > we could mask the area out by using techniques we learned in
 > > [the _Drawing and Bitwise Operations_ episode]({{ page.root }}{% link _episodes/04-drawing.md %}).
 > >
 > > However, a closer inspection of the binary images raises some issues with

--- a/_episodes/09-challenges.md
+++ b/_episodes/09-challenges.md
@@ -50,7 +50,7 @@ and `data/colonies-03.tif`.
 > [thresholding]({{ page.root }}{% link _episodes/07-thresholding.md %}) and
 > [connected component analysis]({{ page.root }}{% link _episodes/08-connected-components.md %}).
 > Try to put your code into a re-usable function,
-> so that it can be applied easily to any image file.
+> so that it can be applied conveniently to any image file.
 >
 > > ## Solution
 > >
@@ -169,7 +169,7 @@ and `data/colonies-03.tif`.
 > > ~~~
 > > {: .language-python}
 > >
-> > Now we can easily do this analysis on all the images via a for loop:
+> > Now we can do this analysis on all the images via a for loop:
 > >
 > > ~~~
 > > for image_filename in ["data/colonies-01.tif", "data/colonies-02.tif", "data/colonies-03.tif"]:


### PR DESCRIPTION
Based on my experience, using words like "easily" in instructions can be frustrating for learners if they encounter difficulties. I removed/edited a few occurrences directly related to exercises. There are other instances where the text is more explanatory and advertises certain techniques or features, and I left the wording unchanged in those cases.