### PR TITLE
Add empty div to create some space before solution blocks

### DIFF
--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -67,8 +67,7 @@ fig, ax = plt.subplots()
 plt.imshow(shapes01)
 ```
 
-![](data/shapes-01.jpg)
-{alt='Image with geometric shapes on white background' .image-with-shadow}
+![](data/shapes-01.jpg){alt='Image with geometric shapes on white background' .image-with-shadow}
 
 Now suppose we want to select only the shapes from the image.
 In other words, we want to leave the pixels belonging to the shapes "on,"
@@ -95,8 +94,7 @@ fig, ax = plt.subplots()
 plt.imshow(blurred_shapes, cmap="gray")
 ```
 
-![](fig/shapes-01-grayscale.png)
-{alt='Grayscale image of the geometric shapes' .image-with-shadow}
+![](fig/shapes-01-grayscale.png){alt='Grayscale image of the geometric shapes' .image-with-shadow}
 
 Next, we would like to apply the threshold `t` such that
 pixels with grayscale values on one side of `t` will be turned "on",

--- a/episodes/08-connected-components.md
+++ b/episodes/08-connected-components.md
@@ -27,8 +27,7 @@ we have covered dividing an image into foreground and background pixels.
 In the shapes example image,
 we considered the coloured shapes as foreground *objects* on a white background.
 
-![](data/shapes-01.jpg)
-{alt='Original shapes image' .image-with-shadow}
+![](data/shapes-01.jpg){alt='Original shapes image' .image-with-shadow}
 
 In thresholding we went from the original image to this version:
 

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ b) completing a Data Carpentry Ecology workshop (with Python) **and** a Data Car
 c) independent exposure to both Python and the Bash shell.
 
 If you're unsure whether you have enough experience to participate in this workshop, please read over
-[this detailed list](instructors/prereqs.md), which gives all of the functions, operators, and other concepts you will need
+[this detailed list](learners/prereqs.md), which gives all of the functions, operators, and other concepts you will need
 to be familiar with.
 
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -69,7 +69,11 @@ e.g. your Desktop or a folder you have created for using in this workshop.
    ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 3. Open a Jupyter notebook:
-  
+
+   :::::::::::::: {.empty-div style="margin-bottom: 50px"}
+   <!-- This div is intentionally empty to allow the solution to float alone -->
+   ::::::::::::::
+
    ::::::::::::::  solution
   
    ## Instructions for Linux \& Mac
@@ -115,6 +119,10 @@ e.g. your Desktop or a folder you have created for using in this workshop.
   
    Upon execution of the cell, a figure with two images should be displayed in an interactive widget. When hovering over the images with the mouse pointer, the pixel coordinates and colour values are displayed below the image.
   
+   :::::::::::::: {.empty-div style="margin-bottom: 50px"}
+   <!-- This div is intentionally empty to allow the solution to float alone -->
+   ::::::::::::::
+
    ::::::::::::::  solution
   
    ## Running Cells in a Notebook


### PR DESCRIPTION
Solutions blocks are more buoyant in the workbench layout and tend to overlay with text. As @zkamvar pointed out in https://github.com/carpentries/lesson-transition/issues/46#issuecomment-1522014660, this can be avoided by inserting an empty div block.