### PR TITLE
Fix headings in Reference extra

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -1,8 +1,6 @@
 ---
-title: 'FIXME'
+title: 'Reference'
 ---
-
-## Glossary
 
 ## Glossary
 


### PR DESCRIPTION
This will stop the Reference extra showing up as FIXME in the dropdown list, and removes the redundant "Glossary" heading from the page.