### PR TITLE
add empty div to give space to floating solution block

### DIFF
--- a/episodes/08-connected-components.md
+++ b/episodes/08-connected-components.md
@@ -321,6 +321,10 @@ plt.imshow(labeled_image)
 plt.axis("off");
 ```
 
+:::::::::::::: {.empty-div style="margin-bottom: 50px"}
+<!-- This div is intentionally empty to allow the solution to float alone -->
+::::::::::::::
+   
 ::::::::::::::  solution
 
 ## Color mappings


### PR DESCRIPTION
Inspired by @uschille in #273, adding an empty div to give the floating solution block in _Connected Component Analysis_ some more space. 