### PR TITLE
Relocate instructor note to Blurring episode

### DIFF
--- a/episodes/06-blurring.md
+++ b/episodes/06-blurring.md
@@ -176,6 +176,16 @@ The same process would be used to determine the green and red channel values,
 and then the kernel would be moved over to apply the filter to the
 next pixel in the image.
 
+:::::::::::::::::::::::::::::::::::::::: instructor
+
+## Terminology about image boundaries
+
+Take care to avoid mixing up the term "edge" to describe the edges of objects
+*within* an image and the outer boundaries of the images themselves. 
+Lack of a clear distinction here may be confusing for learners.
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::
+
 :::::::::::::::::::::::::::::::::::::::::  callout
 
 ## Image edges

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -23,10 +23,6 @@ title: Instructor Notes
 - Be aware that learners might get surprising results in the *Keeping only low intensity pixels* exercise, if `plt.imshow` is called without the `vmax` parameter.
   A detailed explanation is given in the *Plotting single channel images (cmap, vmin, vmax)* callout box.
 
-## Blurring
-
-- Take care to avoid mixing up the term "edge" to describe the edges of objects
-  *within* an image and the outer boundaries of the images themselves. Lack of a clear distinction here may be confusing for learners.
 
 ## Questions from Learners
 


### PR DESCRIPTION
This relocates the note about terminology around image boundaries to the Blurring episode, where it is most relevant. It adds the note into that episode as an inline Instructor Note.