### PR TITLE
Convert the image to float.

### DIFF
--- a/episodes/05-creating-histograms.md
+++ b/episodes/05-creating-histograms.md
@@ -201,6 +201,9 @@ it to the `np.histogram` function.
 # read the image as grayscale from the outset
 plant_seedling = iio.imread(uri="data/plant-seedling.jpg", mode="L")
 
+# convert the image to float dtype with a value range from 0 to 1
+plant_seedling = skimage.util.img_as_float(plant_seedling)
+
 # display the image
 fig, ax = plt.subplots()
 plt.imshow(plant_seedling, cmap="gray")


### PR DESCRIPTION
Without converting the image to float with value that range from 0 to 1, the histogram return an inaccurate representation of the mask image.