### PR TITLE
Move optional episode metadata to fenced divs

### DIFF
--- a/learners/edge-detection.md
+++ b/learners/edge-detection.md
@@ -1,19 +1,24 @@
 ---
 title: 'Extra Episode: Edge Detection'
-teaching: ??
-exercises: ??
-questions: How can we automatically detect the edges of the objects in an image?
-objectives:
+teaching: 0
+exercises: 0
+---
+
+:::::::::::::::::::::::::::::: questions
+
+- How can we automatically detect the edges of the objects in an image?
+
+::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::: objectives
+
 - Apply Canny edge detection to an image.
 - Explain how we can use sliders to expedite finding appropriate parameter values
   for our skimage function calls.
 - Create skimage windows with sliders and associated callback functions.
-keypoints:
-- The `skimage.viewer.ImageViewer` is extended using a `skimage.viewer.plugins.Plugin`.
-- We supply a filter function callback when creating a Plugin.
-- Parameters of the callback function are manipulated interactively by creating sliders
-  with the `skimage.viewer.widgets.slider()` function and adding them to the plugin.
----
+
+:::::::::::::::::::::::::::::::::::::::::
+
 
 In this episode, we will learn how to use skimage functions to apply *edge
 detection* to an image.
@@ -484,4 +489,11 @@ These include `skimage.filters.sobel()`,
 which you will recognise as part of the Canny method.
 Another choice is `skimage.filters.laplace()`.
 
+:::::::::::::::::::::::::::::: keypoints
 
+- The `skimage.viewer.ImageViewer` is extended using a `skimage.viewer.plugins.Plugin`.
+- We supply a filter function callback when creating a Plugin.
+- Parameters of the callback function are manipulated interactively by creating sliders
+  with the `skimage.viewer.widgets.slider()` function and adding them to the plugin.
+
+::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
The questions, objectives, and key points for the optional Edge Detection episode were still in the old YAML front matter from the previous lesson infrastructure. This PR moves them out to their own fenced divs so they should appear in the rendered page once again.