### PR TITLE
Simplify one-line docstrings for snippets

### DIFF
--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -77,16 +77,13 @@ the distinction between matrices and arrays is not important, we don't really ca
 in its memory. The important thing is that the computer stores values describing the pixels in images, as arrays. And
 the terms matrix and array can be used interchangeably.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 First, the necessary imports:
 
 ```python
-"""
- * Python libraries for learning and performing image processing.
- *
-"""
+"""Python libraries for learning and performing image processing."""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import ipympl
@@ -254,9 +251,9 @@ Using array slicing, we can then address and assign a new value to that position
 ```python
 zero = iio.imread(uri="data/eight.tif")
 zero[2,1]= 1.0
-"""
-The follwing line of code creates a new figure for imshow to use in displaying our output. Without it, plt.imshow() would overwrite our previous image in the cell above
-"""
+
+# The follwing line of code creates a new figure for imshow to use in displaying our output.
+# Without it, plt.imshow() would overwrite our previous image in the cell above
 fig, ax = plt.subplots()
 plt.imshow(zero)
 print(zero)
@@ -311,7 +308,6 @@ can be especially helpful in cases where you need to transpose image viewer data
 provided in *x,y* format to *y,x* format.  Thus, we will use *cx* and *ry* where appropriate
 to help bridge these two approaches.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::  challenge
@@ -346,8 +342,6 @@ print(five)
 ```
 
 ![](fig/five.png){alt='Image of 5'}
-
-
 
 :::::::::::::::::::::::::
 

--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -252,7 +252,7 @@ Using array slicing, we can then address and assign a new value to that position
 zero = iio.imread(uri="data/eight.tif")
 zero[2,1]= 1.0
 
-# The follwing line of code creates a new figure for imshow to use in displaying our output.
+# The following line of code creates a new figure for imshow to use in displaying our output.
 # Without it, plt.imshow() would overwrite our previous image in the cell above
 fig, ax = plt.subplots()
 plt.imshow(zero)

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -50,10 +50,7 @@ and save an image to a different format.
 Here are the first few lines:
 
 ```python
-"""
- * Python program to open, display, and save an image.
- *
-"""
+"""Python program to open, display, and save an image."""
 # read image
 chair = iio.imread(uri="data/chair.jpg")
 ```
@@ -97,7 +94,6 @@ that was loaded into Python!*
 If the image metadata is important to you, be sure to **always keep an unchanged
 copy of the original image!**
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::::  callout
@@ -110,7 +106,6 @@ Note that this is not always the case.
 For example, if we are editing a document in Microsoft Word,
 and we save the document as `paper.pdf` instead of `paper.docx`,
 the file *is not* saved as a PDF document.
-
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -145,7 +140,6 @@ The style we will use in this workshop is to name each argument, like this:
 This style will make it easier for you to learn how to use the variety of
 functions we will cover in this workshop.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::  challenge
@@ -179,7 +173,6 @@ parameters that allow the user to control this interpolation. You
 can find more details in the [scikit-image
 documentation](https://scikit-image.org/docs/stable/api/skimage.transform.html#skimage.transform.resize).
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Image files on disk are normally stored as whole numbers for space efficiency,
@@ -210,10 +203,7 @@ or the OS file browser if it is configured to show file sizes.
 Here is what your Python script might look like.
 
 ```python
-"""
- * Python script to read an image, resize it, and save it
- * under a different name.
-"""
+"""Python script to read an image, resize it, and save it under a different name."""
 
 # read in image
 chair = iio.imread(uri="data/chair.jpg")
@@ -236,8 +226,6 @@ plt.imshow(resized_chair)
 The script resizes the `data/chair.jpg` image by a factor of 10 in both dimensions,
 saves the result to the `data/resized_chair.jpg` file,
 and displays original and resized for comparision.
-
-
 
 :::::::::::::::::::::::::
 
@@ -276,14 +264,10 @@ We will start by reading the image and displaying it.
 
 When loading an image with `imageio`, in certain situations the image is stored in a read-only array. If you attempt to manipulate the pixels in a read-only array, you will receive an error message `ValueError: assignment destination is read-only`. In order to make the image array writeable, we can create a copy with `image = np.array(image)` before manipulating the pixel values.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ```python
-"""
-* Python script to ignore low intensity pixels in an image.
-*
-"""
+"""Python script to ignore low intensity pixels in an image."""
 
 # read input image
 maize_roots = iio.imread(uri="data/maize-root-cluster.jpg")
@@ -341,14 +325,10 @@ To account for this, we will use the US English spelling, `color`,
 in example Python code throughout the lesson.
 You will encounter a similar approach with "centre" and `center`.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ```python
-"""
-* Python script to load a color image as grayscale.
-*
-"""
+"""Python script to load a color image as grayscale."""
 
 # read input image
 chair = iio.imread(uri="data/chair.jpg")
@@ -367,10 +347,7 @@ We can also load colour images as grayscale directly by
 passing the argument `mode="L"` to `iio.imread()`.
 
 ```python
-"""
-* Python script to load a color image as grayscale.
-*
-"""
+"""Python script to load a color image as grayscale."""
 
 # read input image, based on filename parameter
 gray_chair = iio.imread(uri="data/chair.jpg", mode="L")
@@ -389,7 +366,6 @@ pass `plugin="pillow"`. If the backend is not specified explicitly, `iio.imread(
 ## Loading images with `imageio`: Pixel type and depth
 
 When loading an image with `mode="L"`, the pixel values are stored as 8-bit integer numbers that can take values in the range 0-255. However, pixel values may also be stored with other types and ranges. For example, some scikit-image functions return the pixel values as floating point numbers in the range 0-1. The type and range of the pixel values are important for the colorscale when plotting, and for masking and thresholding images as we will see later in the lesson. If you are unsure about the type of the pixel values, you can inspect it with `print(image.dtype)`. For the example above, you should find that it is `dtype('uint8')` indicating 8-bit integer numbers.
-
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -469,7 +445,6 @@ you can specify them via `vmin` and `vmax` to get the desired output.
 If you forget about this, it can lead to unexpected results. Try removing
 the `vmax` parameter from the sudoku challenge solution and see what happens.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ## Access via slicing
@@ -514,10 +489,7 @@ indicates that we want all three colour channels in our new image.
 A script to create the subimage would start by loading the image:
 
 ```python
-"""
- * Python script demonstrating image modification and creation via
- * NumPy array slicing.
-"""
+"""Python script demonstrating image modification and creation via NumPy array slicing."""
 
 # load and display original image
 board = iio.imread(uri="data/board.jpg")
@@ -578,10 +550,7 @@ Here is the completed Python program to select only the plant and roots
 in the image.
 
 ```python
-"""
- * Python script to extract a sub-image containing only the plant and
- * roots in an existing image.
-"""
+"""Python script to extract a sub-image containing only the plant and roots in an existing image."""
 
 # load and display original image
 maize_roots = iio.imread(uri="data/maize-root-cluster.jpg")

--- a/learners/edge-detection.md
+++ b/learners/edge-detection.md
@@ -19,7 +19,6 @@ exercises: 0
 
 :::::::::::::::::::::::::::::::::::::::::
 
-
 In this episode, we will learn how to use scikit-image functions to apply *edge
 detection* to an image.
 In edge detection, we find the boundaries or edges of objects in an image,
@@ -148,10 +147,9 @@ the program reads the command-line arguments and
 saves them in their respective variables.
 
 ```python
-"""
- * Python script to demonstrate Canny edge detection.
- *
- * usage: python CannyEdge.py <filename> <sigma> <low_threshold> <high_threshold>
+"""Python script to demonstrate Canny edge detection.
+
+usage: python CannyEdge.py <filename> <sigma> <low_threshold> <high_threshold>
 """
 import imageio.v3 as iio
 import matplotlib.pyplot as plt
@@ -271,11 +269,9 @@ reading the image in grayscale,
 and creating a window.
 
 ```python
-"""
- * Python script to demonstrate Canny edge detection
- * with sliders to adjust the thresholds.
- *
- * usage: python CannyTrack.py <filename>
+"""Python script to demonstrate Canny edge detection with sliders to adjust the thresholds.
+
+usage: python CannyTrack.py <filename>
 """
 import imageio.v3 as iio
 import matplotlib.pyplot as plt
@@ -345,7 +341,6 @@ The filter function will be called with the slider parameters
 according to their *names* as *keyword* arguments.
 So it is very important to name the sliders appropriately.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Finally, we add the plugin the viewer and display the resulting user interface:
@@ -385,8 +380,6 @@ The coloured shape edge image above was produced with a low threshold
 value of 0.05 and a high threshold value of 0.07.
 You may be able to achieve similar results with other threshold values.
 
-
-
 :::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -419,11 +412,9 @@ Here is a program that uses a slider to vary the threshold value used in
 a simple, fixed-level thresholding process.
 
 ```python
-"""
- * Python program to use a slider to control fixed-level
- * thresholding value.
- *
- * usage: python interactive_thresholding.py <filename>
+"""Python program to use a slider to control fixed-level thresholding value.
+
+usage: python interactive_thresholding.py <filename>
 """
 
 import imageio.v3 as iio
@@ -465,8 +456,6 @@ blurring with a sigma of 1.5 and a threshold value of 0.45:
 
 ![](fig/maize-roots-threshold.png){alt='Thresholded maize roots'}
 
-
-
 :::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -489,7 +478,6 @@ These include `skimage.filters.sobel()`,
 which you will recognise as part of the Canny method.
 Another choice is `skimage.filters.laplace()`.
 
-
 :::::::::::::::::::::::::::::: keypoints
 
 - The `skimage.viewer.ImageViewer` is extended using a `skimage.viewer.plugins.Plugin`.
@@ -498,4 +486,3 @@ Another choice is `skimage.filters.laplace()`.
   with the `skimage.viewer.widgets.slider()` function and adding them to the plugin.
 
 ::::::::::::::::::::::::::::::::::::::::
-


### PR DESCRIPTION
Closes #291 

This PR removes the `*` from the triple-quoted docstrings in some of the code snippets. This should hopefully make them look more like the Python standards set it [PEP 257](https://peps.python.org/pep-0257/#one-line-docstrings) that learners are likely encounter outside the lesson.

The PR also removes some extra blank lines that my Markdown linter didn't like.