### PR TITLE
Use new import convention for scikit-image.

### DIFF
--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -86,8 +86,8 @@ First, the necessary imports:
 
 import imageio.v3 as iio
 import ipympl
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import skimage as ski
 ```
 

--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -84,11 +84,11 @@ First, the necessary imports:
 ```python
 """Python libraries for learning and performing image processing."""
 
+import imageio.v3 as iio
+import ipympl
 import numpy as np
 import matplotlib.pyplot as plt
-import ipympl
-import imageio.v3 as iio
-import skimage
+import skimage as ski
 ```
 
 The `v3` module of imageio (`imageio.v3`) is imported as `iio`. This module
@@ -112,7 +112,7 @@ You will encounter several different forms of `import` statement.
 import skimage                 # form 1, load whole skimage library
 import skimage.draw            # form 2, load skimage.draw module only
 from skimage.draw import disk  # form 3, load only the disk function
-import numpy as np             # form 4, load all of numpy into an object called np
+import skimage as ski          # form 4, load all of skimage into an object called ski
 ```
 
 ::::::::::::::  solution
@@ -126,18 +126,14 @@ e.g., to access the `disk` function used in [the drawing episode](04-drawing.md)
 you would write `skimage.draw.disk()`.
 
 Form 2 loads only the `draw` module of `skimage` into the program.
-When we run the code,
-the program will take less time and use less memory
-because we will not load the whole scikit-image library.
 The syntax needed to use the module remains unchanged:
 to access the `disk` function,
 we would use the same function call as given for form 1.
 
-To further reduce the time and memory requirements for your program,
-form 3 can be used to import only a specific function/class from a library/module.
+Form 3 can be used to import only a specific function/class from a library/module.
 Unlike the other forms, when this approach is used,
 the imported function or class can be called by its name only,
-without prefixing it with the name of the module/library from which it was loaded,
+without prefixing it with the name of the library/module from which it was loaded,
 i.e., `disk()` instead of `skimage.draw.disk()` using the example above.
 One hazard of this form is that importing like this will overwrite any
 object with the same name that was defined/imported earlier in the program,
@@ -148,7 +144,7 @@ Finally, the `as` keyword can be used when importing,
 to define a name to be used as shorthand for the library/module being imported.
 This name is referred to as an alias. Typically, using an alias (such as
 `np` for the NumPy library) saves us a little typing.
-You may see `as` combined with any of the other first three forms of `import` statement.
+You may see `as` combined with any of the other first three forms of `import` statements.
 
 Which form is used often depends on
 the size and number of additional tools being loaded into the program.

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -26,14 +26,11 @@ for accessing and changing digital images.
 ## First, import the packages needed for this episode
 
 ```python
+import imageio.v3 as iio
+import ipympl
 import numpy as np
 import matplotlib.pyplot as plt
-import ipympl
-import imageio.v3 as iio
-import skimage
-import skimage.color
-import skimage.transform
-import skimage.util
+import skimage as ski
 ```
 
 ## Reading, displaying, and saving images
@@ -146,19 +143,18 @@ functions we will cover in this workshop.
 
 ## Resizing an image (10 min)
 
-Add `import skimage.transform` and `import skimage.util` to your list of imports.
 Using the `chair.jpg` image located in the data folder,
 write a Python script to read your image into a variable named `chair`.
 Then, resize the image to 10 percent of its current size using these lines of code:
 
 ```python
 new_shape = (chair.shape[0] // 10, chair.shape[1] // 10, chair.shape[2])
-resized_chair = skimage.transform.resize(image=chair, output_shape=new_shape)
-resized_chair = skimage.util.img_as_ubyte(resized_chair)
+resized_chair = ski.transform.resize(image=chair, output_shape=new_shape)
+resized_chair = ski.util.img_as_ubyte(resized_chair)
 ```
 
 As it is used here,
-the parameters to the `skimage.transform.resize()` function are
+the parameters to the `ski.transform.resize()` function are
 the image to transform, `chair`,
 the dimensions we want the new image to have, `new_shape`.
 
@@ -168,7 +164,7 @@ Note that the pixel values in the new image are an approximation of
 the original values and should not be confused with actual, observed
 data. This is because scikit-image interpolates the pixel values when
 reducing or increasing the size of an
-image. `skimage.transform.resize` has a number of optional
+image. `ski.transform.resize` has a number of optional
 parameters that allow the user to control this interpolation. You
 can find more details in the [scikit-image
 documentation](https://scikit-image.org/docs/stable/api/skimage.transform.html#skimage.transform.resize).
@@ -178,7 +174,7 @@ documentation](https://scikit-image.org/docs/stable/api/skimage.transform.html#s
 Image files on disk are normally stored as whole numbers for space efficiency,
 but transformations and other math operations often result in
 conversion to floating point numbers.
-Using the `skimage.util.img_as_ubyte()` method converts it back to whole numbers
+Using the `ski.util.img_as_ubyte()` method converts it back to whole numbers
 before we save it back to disk.
 If we don't convert it before saving,
 `iio.imwrite()` may not recognise it as image data.
@@ -210,8 +206,8 @@ chair = iio.imread(uri="data/chair.jpg")
 
 # resize the image
 new_shape = (chair.shape[0] // 10, chair.shape[1] // 10, chair.shape[2])
-resized_chair = skimage.transform.resize(image=chair, output_shape=new_shape)
-resized_chair = skimage.util.img_as_ubyte(resized_chair)
+resized_chair = ski.transform.resize(image=chair, output_shape=new_shape)
+resized_chair = ski.util.img_as_ubyte(resized_chair)
 
 # write out image
 iio.imwrite(uri="data/resized_chair.jpg", image=resized_chair)
@@ -301,12 +297,12 @@ the result is an image in which the extraneous background detail has been remove
 
 It is often easier to work with grayscale images, which have a single channel,
 instead of colour images, which have three channels.
-scikit-image offers the function `skimage.color.rgb2gray()` to achieve this.
+scikit-image offers the function `ski.color.rgb2gray()` to achieve this.
 This function adds up the three colour channels in a way that matches
 human colour perception,
 see [the scikit-image documentation for details](https://scikit-image.org/docs/dev/api/skimage.color.html#skimage.color.rgb2gray).
 It returns a grayscale image with floating point values in the range from 0 to 1.
-We can use the function `skimage.util.img_as_ubyte()` in order to convert it back to the
+We can use the function `ski.util.img_as_ubyte()` in order to convert it back to the
 original data type and the data range back 0 to 255.
 Note that it is often better to use image values represented by floating point values,
 because using floating point numbers is numerically more stable.
@@ -320,7 +316,7 @@ which is why we use "colour" in the explanatory text of this lesson.
 However, scikit-image contains many modules and functions that include
 the US English spelling, `color`.
 The exact spelling matters here,
-e.g. you will encounter an error if you try to run `skimage.colour.rgb2gray()`.
+e.g. you will encounter an error if you try to run `ski.colour.rgb2gray()`.
 To account for this, we will use the US English spelling, `color`,
 in example Python code throughout the lesson.
 You will encounter a similar approach with "centre" and `center`.
@@ -338,7 +334,7 @@ fig, ax = plt.subplots()
 plt.imshow(chair)
 
 # convert to grayscale and display
-gray_chair = skimage.color.rgb2gray(chair)
+gray_chair = ski.color.rgb2gray(chair)
 fig, ax = plt.subplots()
 plt.imshow(gray_chair, cmap="gray")
 ```
@@ -576,8 +572,8 @@ iio.imwrite(uri="data/clipped_maize.jpg", image=clipped_maize)
 
 - Images are read from disk with the `iio.imread()` function.
 - We create a window that automatically scales the displayed image with Matplotlib and calling `show()` on the global figure object.
-- Colour images can be transformed to grayscale using `skimage.color.rgb2gray()` or, in many cases, be read as grayscale directly by passing the argument `mode="L"` to `iio.imread()`.
-- We can resize images with the `skimage.transform.resize()` function.
+- Colour images can be transformed to grayscale using `ski.color.rgb2gray()` or, in many cases, be read as grayscale directly by passing the argument `mode="L"` to `iio.imread()`.
+- We can resize images with the `ski.transform.resize()` function.
 - NumPy array commands, such as `image[image < 128] = 0`, can be used to manipulate the pixels of an image.
 - Array slicing can be used to extract sub-images or modify areas of images, e.g., `clip = image[60:150, 135:480, :]`.
 - Metadata is not retained when images are loaded as scikit-image images.

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -28,8 +28,8 @@ for accessing and changing digital images.
 ```python
 import imageio.v3 as iio
 import ipympl
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import skimage as ski
 ```
 

--- a/episodes/04-drawing.md
+++ b/episodes/04-drawing.md
@@ -27,17 +27,16 @@ based on changes in colour or shape.
 ## First, import the packages needed for this episode
 
 ```python
+import imageio.v3 as iio
+import ipympl
 import numpy as np
 import matplotlib.pyplot as plt
-import ipympl
-import imageio.v3 as iio
-import skimage
-import skimage.draw
+import skimage as ski
+
 %matplotlib widget
 ```
 
-Here, we import the `draw` submodule of `skimage` as well as packages familiar
-from earlier in the lesson.
+Here, we import the same packages as earlier in the lesson.
 
 ## Drawing on images
 
@@ -113,7 +112,7 @@ Next, we draw a filled, rectangle on the mask:
 
 ```python
 # Draw filled rectangle on the mask image
-rr, cc = skimage.draw.rectangle(start=(357, 44), end=(740, 720))
+rr, cc = ski.draw.rectangle(start=(357, 44), end=(740, 720))
 mask[rr, cc] = False
 
 # Display mask image
@@ -139,7 +138,7 @@ it is wise to check how the function is used, via
 or other usage examples on programming-related sites such as
 [Stack Overflow](https://stackoverflow.com/).
 Basic information about scikit-image functions can be found interactively in Python,
-via commands like `help(skimage)` or `help(skimage.draw.rectangle)`.
+via commands like `help(ski)` or `help(ski.draw.rectangle)`.
 Take notes in your lab notebook.
 And, it is always wise to run some test code to verify
 that the functions your program uses are behaving in the manner you intend.
@@ -170,13 +169,13 @@ such that it is easier for other people to understand your code.
 ## Other drawing operations (15 min)
 
 There are other functions for drawing on images,
-in addition to the `skimage.draw.rectangle()` function.
+in addition to the `ski.draw.rectangle()` function.
 We can draw circles, lines, text, and other shapes as well.
 These drawing functions may be useful later on, to help annotate images
 that our programs produce.
 Practice some of these functions here.
 
-Circles can be drawn with the `skimage.draw.disk()` function,
+Circles can be drawn with the `ski.draw.disk()` function,
 which takes two parameters:
 the (ry, cx) point of the centre of the circle,
 and the radius of the circle.
@@ -184,7 +183,7 @@ There is an optional `shape` parameter that can be supplied to this function.
 It will limit the output coordinates for cases where the circle
 dimensions exceed the ones of the image.
 
-Lines can be drawn with the `skimage.draw.line()` function,
+Lines can be drawn with the `ski.draw.line()` function,
 which takes four parameters:
 the (ry, cx) coordinate of one end of the line,
 and the (ry, cx) coordinate of the other end of the line.
@@ -215,7 +214,7 @@ Drawing a circle:
 
 ```python
 # Draw a blue circle with centre (200, 300) in (ry, cx) coordinates, and radius 100
-rr, cc = skimage.draw.disk(center=(200, 300), radius=100, shape=canvas.shape[0:2])
+rr, cc = ski.draw.disk(center=(200, 300), radius=100, shape=canvas.shape[0:2])
 canvas[rr, cc] = (0, 0, 255)
 ```
 
@@ -223,7 +222,7 @@ Drawing a line:
 
 ```python
 # Draw a green line from (400, 200) to (500, 700) in (ry, cx) coordinates
-rr, cc = skimage.draw.line(r0=400, c0=200, r1=500, c1=700)
+rr, cc = ski.draw.line(r0=400, c0=200, r1=500, c1=700)
 canvas[rr, cc] = (0, 255, 0)
 ```
 
@@ -249,7 +248,7 @@ canvas = np.zeros(shape=(600, 800, 3), dtype="uint8")
 
 # draw a blue circle at a random location 15 times
 for i in range(15):
-    rr, cc = skimage.draw.disk(center=(
+    rr, cc = ski.draw.disk(center=(
          random.randrange(600),
          random.randrange(800)),
          radius=50,
@@ -278,7 +277,7 @@ for i in range(15):
     x = random.random()
     if x < 0.33:
         # draw a blue circle at a random location
-        rr, cc = skimage.draw.disk(center=(
+        rr, cc = ski.draw.disk(center=(
             random.randrange(600),
             random.randrange(800)),
             radius=50,
@@ -287,7 +286,7 @@ for i in range(15):
         color = (0, 0, 255)
     elif x < 0.66:
         # draw a green line at a random location
-        rr, cc = skimage.draw.line(
+        rr, cc = ski.draw.line(
             r0=random.randrange(600),
             c0=random.randrange(800),
             r1=random.randrange(600),
@@ -296,7 +295,7 @@ for i in range(15):
         color = (0, 255, 0)
     else:
         # draw a red rectangle at a random location
-        rr, cc = skimage.draw.rectangle(
+        rr, cc = ski.draw.rectangle(
             start=(random.randrange(600), random.randrange(800)),
             extent=(50, 50),
             shape=canvas.shape[0:2],
@@ -359,7 +358,7 @@ maize_seedlings = iio.imread(uri="data/maize-seedlings.tif")
 mask = np.ones(shape=maize_seedlings.shape[0:2], dtype="bool")
 
 # Draw a filled rectangle on the mask image
-rr, cc = skimage.draw.rectangle(start=(357, 44), end=(740, 720))
+rr, cc = ski.draw.rectangle(start=(357, 44), end=(740, 720))
 mask[rr, cc] = False
 ```
 
@@ -416,7 +415,7 @@ remote = np.array(remote)
 mask = np.ones(shape=remote.shape[0:2], dtype="bool")
 
 # Draw a filled rectangle on the mask image
-rr, cc = skimage.draw.rectangle(start=(93, 1107), end=(1821, 1668))
+rr, cc = ski.draw.rectangle(start=(93, 1107), end=(1821, 1668))
 mask[rr, cc] = False
 
 # Apply the mask
@@ -484,7 +483,7 @@ with open("data/centers.txt", "r") as center_file:
         ry = int(coordinates[1])
 
         # ... and drawing a circle on the mask
-        rr, cc = skimage.draw.disk(center=(ry, cx), radius=16, shape=wellplate.shape[0:2])
+        rr, cc = ski.draw.disk(center=(ry, cx), radius=16, shape=wellplate.shape[0:2])
         mask[rr, cc] = False
 
 # apply the mask
@@ -554,7 +553,7 @@ for row in range(12):
     for col in range(8):
 
         # ... and drawing a circle on the mask
-        rr, cc = skimage.draw.disk(center=(ry, cx), radius=16, shape=wellplate.shape[0:2])
+        rr, cc = ski.draw.disk(center=(ry, cx), radius=16, shape=wellplate.shape[0:2])
         mask[rr, cc] = False
         cx += deltaCX
     # after one complete row, move to next row
@@ -575,7 +574,7 @@ plt.imshow(wellplate)
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
 - We can use the NumPy `zeros()` function to create a blank, black image.
-- We can draw on scikit-image images with functions such as `skimage.draw.rectangle()`, `skimage.draw.disk()`, `skimage.draw.line()`, and more.
+- We can draw on scikit-image images with functions such as `ski.draw.rectangle()`, `ski.draw.disk()`, `ski.draw.line()`, and more.
 - The drawing functions return indices to pixels that can be set directly.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/04-drawing.md
+++ b/episodes/04-drawing.md
@@ -29,8 +29,8 @@ based on changes in colour or shape.
 ```python
 import imageio.v3 as iio
 import ipympl
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import skimage as ski
 
 %matplotlib widget

--- a/episodes/05-creating-histograms.md
+++ b/episodes/05-creating-histograms.md
@@ -27,8 +27,8 @@ display histograms for images.
 ```python
 import imageio.v3 as iio
 import ipympl
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import skimage as ski
 
 %matplotlib widget

--- a/episodes/05-creating-histograms.md
+++ b/episodes/05-creating-histograms.md
@@ -25,12 +25,12 @@ display histograms for images.
 ## First, import the packages needed for this episode
 
 ```python
+import imageio.v3 as iio
+import ipympl
 import numpy as np
 import matplotlib.pyplot as plt
-import ipympl
-import imageio.v3 as iio
-import skimage
-import skimage.draw
+import skimage as ski
+
 %matplotlib widget
 ```
 
@@ -61,7 +61,7 @@ Here we load the image in grayscale instead of full colour, and display it:
 plant_seedling = iio.imread(uri="data/plant-seedling.jpg", mode="L")
 
 # convert the image to float dtype with a value range from 0 to 1
-plant_seedling = skimage.util.img_as_float(plant_seedling)
+plant_seedling = ski.util.img_as_float(plant_seedling)
 
 # display the image
 fig, ax = plt.subplots()
@@ -73,7 +73,7 @@ plt.imshow(plant_seedling, cmap="gray")
 Again, we use the `iio.imread()` function to load our image.
 Then, we convert the grayscale image of integer dtype, with 0-255 range, into
 a floating-point one with 0-1 range, by calling the function
-`skimage.util.img_as_float`.
+`ski.util.img_as_float`.
 We will keep working with images in the value range 0 to 1 in this lesson.
 
 We now use the function `np.histogram` to compute the histogram of our image
@@ -205,9 +205,9 @@ plant_seedling = iio.imread(uri="data/plant-seedling.jpg", mode="L")
 fig, ax = plt.subplots()
 plt.imshow(plant_seedling, cmap="gray")
 
-# create mask here, using np.zeros() and skimage.draw.rectangle()
+# create mask here, using np.zeros() and ski.draw.rectangle()
 mask = np.zeros(shape=plant_seedling.shape, dtype="bool")
-rr, cc = skimage.draw.rectangle(start=(199, 410), end=(384, 485))
+rr, cc = ski.draw.rectangle(start=(199, 410), end=(384, 485))
 mask[rr, cc] = True
 
 # display the mask
@@ -403,7 +403,7 @@ And, the program should produce a colour histogram that looks like this:
 ```python
 # create a circular mask to select the 7th well in the first row
 mask = np.zeros(shape=wellplate.shape[0:2], dtype="bool")
-circle = skimage.draw.disk(center=(240, 1053), radius=49, shape=wellplate.shape[0:2])
+circle = ski.draw.disk(center=(240, 1053), radius=49, shape=wellplate.shape[0:2])
 mask[circle] = 1
 
 # just for display:

--- a/episodes/06-blurring.md
+++ b/episodes/06-blurring.md
@@ -35,7 +35,7 @@ smooth rather than sudden.
 The effect is to average out rapid changes in pixel intensity.
 Blurring is a very common operation we need to perform before other tasks such as
 [thresholding](07-thresholding.md).
-There are several different blurring functions in the `skimage.filters` module,
+There are several different blurring functions in the `ski.filters` module,
 so we will focus on just one here, the *Gaussian blur*.
 
 :::::::::::::::::::::::::::::::::::::::::  callout
@@ -259,10 +259,11 @@ an example of blurring an image with the scikit-image Gaussian blur function.
 First, import the packages needed for this episode:
 
 ```python
-import matplotlib.pyplot as plt
-import ipympl
 import imageio.v3 as iio
-import skimage.filters
+import ipympl
+import matplotlib.pyplot as plt
+import skimage as ski
+
 %matplotlib widget
 ```
 
@@ -284,11 +285,11 @@ Next, we apply the gaussian blur:
 sigma = 3.0
 
 # apply Gaussian blur, creating a new image
-blurred = skimage.filters.gaussian(
+blurred = ski.filters.gaussian(
     image, sigma=(sigma, sigma), truncate=3.5, channel_axis=-1)
 ```
 
-The first two arguments to `skimage.filters.gaussian()` are the image to blur,
+The first two arguments to `ski.filters.gaussian()` are the image to blur,
 `image`, and a tuple defining the sigma to use in ry- and cx-direction,
 `(sigma, sigma)`.
 The third parameter `truncate` is meant to pass the radius of the kernel in
@@ -303,7 +304,7 @@ For example, for a `sigma` of 1.0 the resulting kernel size would be 7,
 while for a `sigma` of 2.0 the kernel size would be 14.
 The default value for `truncate` in scikit-image is 4.0.
 
-The last argument we passed to `skimage.filters.gaussian()` is used to
+The last argument we passed to `ski.filters.gaussian()` is used to
 specify the dimension which contains the (colour) channels.
 Here, it is the last dimension;
 recall that, in Python, the `-1` index refers to the last position.
@@ -348,14 +349,14 @@ For instance, let's look for the intensities of the pixels along the horizontal
 line at `Y=150`:
 
 ```python
-import matplotlib.pyplot as plt
 import imageio.v3 as iio
-import skimage.color
+import matplotlib.pyplot as plt
+import skimage as ski
 
 # read colonies color image and convert to grayscale
 #
 image = iio.imread('data/colonies-01.tif')
-image_gray = skimage.color.rgb2gray(image)
+image_gray = ski.color.rgb2gray(image)
 
 # define the pixels for which we want to view the intensity (profile)
 #
@@ -410,9 +411,9 @@ And now, how does the same set of pixels look in the corresponding *blurred* ima
 ```python
 # first, create a blurred version of (grayscale) image
 #
-import skimage.filters
+import skimage as ski
 
-image_blur = skimage.filters.gaussian(image_gray, sigma=3)
+image_blur = ski.filters.gaussian(image_gray, sigma=3)
 
 # like before, plot the pixels profile along "Y"
 #
@@ -516,7 +517,7 @@ For example, a sigma of 1.0 in the ry direction, and 6.0 in the cx direction.
 
 ```python
 # apply Gaussian blur, with a sigma of 1.0 in the ry direction, and 6.0 in the cx direction
-blurred = skimage.filters.gaussian(
+blurred = ski.filters.gaussian(
     image, sigma=(1.0, 6.0), truncate=3.5, channel_axis=-1
 )
 
@@ -554,7 +555,7 @@ for a list of available filters.
 
 - Applying a low-pass blurring filter smooths edges and removes noise from an image.
 - Blurring is often used as a first step before we perform thresholding or edge detection.
-- The Gaussian blur can be applied to an image with the `skimage.filters.gaussian()` function.
+- The Gaussian blur can be applied to an image with the `ski.filters.gaussian()` function.
 - Larger sigma values may remove more noise, but they will also remove detail from an image.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -48,8 +48,8 @@ import glob
 
 import imageio.v3 as iio
 import ipympl
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import skimage as ski
 
 %matplotlib widget

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -44,13 +44,14 @@ select the parts of an image we are interested in.
 ## First, import the packages needed for this episode
 
 ```python
-import numpy as np
 import glob
-import matplotlib.pyplot as plt
-import ipympl
+
 import imageio.v3 as iio
-import skimage.color
-import skimage.filters
+import ipympl
+import numpy as np
+import matplotlib.pyplot as plt
+import skimage as ski
+
 %matplotlib widget
 ```
 
@@ -85,10 +86,10 @@ and de-noise it as in [the *Blurring Images* episode](06-blurring.md).
 
 ```python
 # convert the image to grayscale
-gray_shapes = skimage.color.rgb2gray(shapes01)
+gray_shapes = ski.color.rgb2gray(shapes01)
 
 # blur the image to denoise
-blurred_shapes = skimage.filters.gaussian(gray_shapes, sigma=1.0)
+blurred_shapes = ski.filters.gaussian(gray_shapes, sigma=1.0)
 
 fig, ax = plt.subplots()
 plt.imshow(blurred_shapes, cmap="gray")
@@ -329,10 +330,10 @@ Let us look at the grayscale histogram of the denoised image.
 
 ```python
 # convert the image to grayscale
-gray_image = skimage.color.rgb2gray(maize_roots)
+gray_image = ski.color.rgb2gray(maize_roots)
 
 # blur the image to denoise
-blurred_image = skimage.filters.gaussian(gray_image, sigma=1.0)
+blurred_image = ski.filters.gaussian(gray_image, sigma=1.0)
 
 # show the histogram of the blurred image
 histogram, bin_edges = np.histogram(blurred_image, bins=256, range=(0.0, 1.0))
@@ -355,14 +356,14 @@ if you are interested),
 but the outcome is that Otsu's method finds a threshold value between
 the two peaks of a grayscale histogram.
 
-The `skimage.filters.threshold_otsu()` function can be used to determine
+The `ski.filters.threshold_otsu()` function can be used to determine
 the threshold automatically via Otsu's method.
 Then NumPy comparison operators can be used to apply it as before.
 Here are the Python commands to determine the threshold `t` with Otsu's method.
 
 ```python
 # perform automatic thresholding
-t = skimage.filters.threshold_otsu(blurred_image)
+t = ski.filters.threshold_otsu(blurred_image)
 print("Found automatic threshold t = {}.".format(t))
 ```
 
@@ -454,10 +455,10 @@ def measure_root_mass(filename, sigma=1.0):
     image = iio.imread(uri=filename, mode="L")
 
     # blur before thresholding
-    blurred_image = skimage.filters.gaussian(image, sigma=sigma)
+    blurred_image = ski.filters.gaussian(image, sigma=sigma)
 
     # perform automatic thresholding to produce a binary image
-    t = skimage.filters.threshold_otsu(blurred_image)
+    t = ski.filters.threshold_otsu(blurred_image)
     binary_mask = blurred_image > t
 
     # determine root mass ratio
@@ -622,7 +623,7 @@ def enhanced_root_mass(filename, sigma):
     image = iio.imread(uri=filename, mode="L")
 
     # blur before thresholding
-    blurred_image = skimage.filters.gaussian(image, sigma=sigma)
+    blurred_image = ski.filters.gaussian(image, sigma=sigma)
 
     # perform binary thresholding to mask the white label and circle
     binary_mask = blurred_image < 0.95
@@ -630,7 +631,7 @@ def enhanced_root_mass(filename, sigma):
     blurred_image[~binary_mask] = 0
 
     # perform automatic thresholding to produce a binary image
-    t = skimage.filters.threshold_otsu(blurred_image)
+    t = ski.filters.threshold_otsu(blurred_image)
     binary_mask = blurred_image > t
 
     # determine root mass ratio
@@ -695,8 +696,8 @@ Here is the code to create the grayscale histogram:
 
 ```python
 bacteria = iio.imread(uri="data/colonies-01.tif")
-gray_image = skimage.color.rgb2gray(bacteria)
-blurred_image = skimage.filters.gaussian(gray_image, sigma=1.0)
+gray_image = ski.color.rgb2gray(bacteria)
+blurred_image = ski.filters.gaussian(gray_image, sigma=1.0)
 histogram, bin_edges = np.histogram(blurred_image, bins=256, range=(0.0, 1.0))
 fig, ax = plt.subplots()
 plt.plot(bin_edges[0:-1], histogram)

--- a/episodes/08-connected-components.md
+++ b/episodes/08-connected-components.md
@@ -218,24 +218,22 @@ Such an image can be produced, e.g., with thresholding.
 Given a thresholded image,
 the connected component analysis produces a new *labeled* image with integer pixel values.
 Pixels with the same value, belong to the same object.
-scikit-image provides connected component analysis in the function `skimage.measure.label()`.
+scikit-image provides connected component analysis in the function `ski.measure.label()`.
 Let us add this function to the already familiar steps of thresholding an image.
 
-First, import the packages needed for this episode
+First, import the packages needed for this episode:
 
 ```python
+import imageio.v3 as iio
+import ipympl
 import numpy as np
 import matplotlib.pyplot as plt
-import ipympl
-import imageio.v3 as iio
-import skimage.color
-import skimage.filters
-import skimage.measure
+import skimage as ski
+
 %matplotlib widget
 ```
 
-Note the new import of `skimage.measure` in order to use the
-`skimage.measure.label` function that performs the CCA.
+In this episode, we will use the `ski.measure.label` function to perform the CCA.
 
 Next, we define a reusable Python function `connected_components`:
 
@@ -244,13 +242,13 @@ def connected_components(filename, sigma=1.0, t=0.5, connectivity=2):
     # load the image
     image = iio.imread(filename)
     # convert the image to grayscale
-    gray_image = skimage.color.rgb2gray(image)
+    gray_image = ski.color.rgb2gray(image)
     # denoise the image with a Gaussian filter
-    blurred_image = skimage.filters.gaussian(gray_image, sigma=sigma)
+    blurred_image = ski.filters.gaussian(gray_image, sigma=sigma)
     # mask the image according to threshold
     binary_mask = blurred_image < t
     # perform connected component analysis
-    labeled_image, count = skimage.measure.label(binary_mask,
+    labeled_image, count = ski.measure.label(binary_mask,
                                                  connectivity=connectivity, return_num=True)
     return labeled_image, count
 ```
@@ -260,7 +258,7 @@ The first four lines of code are familiar from
 
 <!-- Note: shapes image: with sigma=2.0, threshold=0.9 -> 11 objects; with sigma=5 -> 8 objects -->
 
-Then we call the `skimage.measure.label` function.
+Then we call the `ski.measure.label` function.
 This function has one positional argument where we pass the `binary_mask`,
 i.e., the binary image to work on.
 With the optional argument `connectivity`,
@@ -277,7 +275,7 @@ the maximum label index as `count`.
 ## Optional parameters and return values
 
 The optional parameter `return_num` changes the data type that is
-returned by the function `skimage.measure.label`.
+returned by the function `ski.measure.label`.
 The number of labels is only returned if `return_num` is *True*.
 Otherwise, the function only returns the labeled image.
 This means that we have to pay attention when assigning
@@ -286,14 +284,14 @@ If we omit the optional parameter `return_num` or pass `return_num=False`,
 we can call the function as
 
 ```python
-labeled_image = skimage.measure.label(binary_mask)
+labeled_image = ski.measure.label(binary_mask)
 ```
 
 If we pass `return_num=True`, the function returns a tuple and we
 can assign it as
 
 ```python
-labeled_image, count = skimage.measure.label(binary_mask, return_num=True)
+labeled_image, count = ski.measure.label(binary_mask, return_num=True)
 ```
 
 If we used the same assignment as in the first case,
@@ -372,17 +370,17 @@ Fortunately, the scikit-image library has tools to cope with this situation.
 
 :::::::::::::::::::::::::
 
-We can use the function `skimage.color.label2rgb()`
+We can use the function `ski.color.label2rgb()`
 to convert the colours in the image
-(recall that we already used the `skimage.color.rgb2gray()` function
+(recall that we already used the `ski.color.rgb2gray()` function
 to convert to grayscale).
-With `skimage.color.label2rgb()`,
+With `ski.color.label2rgb()`,
 all objects are coloured according to a list of colours that can be customised.
 We can use the following commands to convert and show the image:
 
 ```python
 # convert the label image to color image
-colored_label_image = skimage.color.label2rgb(labeled_image, bg_label=0)
+colored_label_image = ski.color.label2rgb(labeled_image, bg_label=0)
 
 fig, ax = plt.subplots()
 plt.imshow(colored_label_image)
@@ -487,7 +485,7 @@ Recall how we determined the root mass in
 [the *Thresholding* episode](07-thresholding.md)
 by counting the pixels in the binary mask.
 But here we want to calculate the area of several objects in the labeled image.
-The scikit-image library provides the function `skimage.measure.regionprops`
+The scikit-image library provides the function `ski.measure.regionprops`
 to measure the properties of labeled regions.
 It returns a list of `RegionProperties` that describe each connected region in the images.
 The properties can be accessed using the attributes of the `RegionProperties` data type.
@@ -498,7 +496,7 @@ We can get a list of areas of the labeled objects as follows:
 
 ```python
 # compute object features and extract object areas
-object_features = skimage.measure.regionprops(labeled_image)
+object_features = ski.measure.regionprops(labeled_image)
 object_areas = [objf["area"] for objf in object_features]
 object_areas
 ```
@@ -519,7 +517,7 @@ it is often helpful to inspect the histogram of an object property.
 For example, we want to look at the distribution of the object areas.
 
 1. Create and examine a [histogram](05-creating-histograms.md)
-  of the object areas obtained with `skimage.measure.regionprops`.
+  of the object areas obtained with `ski.measure.regionprops`.
 2. What does the histogram tell you about the objects?
 
 :::::::::::::::  solution
@@ -597,7 +595,7 @@ print("Found", len(large_objects), "objects!")
 Another option is to use NumPy arrays to create the list of large objects.
 We first create an array `object_areas` containing the object areas,
 and an array `object_labels` containing the object labels.
-The labels of the objects are also returned by `skimage.measure.regionprops`.
+The labels of the objects are also returned by `ski.measure.regionprops`.
 We have already seen that we can create boolean arrays using comparison operators.
 Here we can use `object_areas > min_area`
 to produce an array that has the same dimension as `object_labels`.
@@ -695,17 +693,17 @@ labeled_image[np.isin(labeled_image,small_objects)] = 0
 ```
 
 An even more elegant way to remove small objects from the image is
-to leverage the `skimage.morphology` module.
-It provides a function `skimage.morphology.remove_small_objects` that
+to leverage the `ski.morphology` module.
+It provides a function `ski.morphology.remove_small_objects` that
 does exactly what we are looking for.
 It can be applied to a binary image and
 returns a mask in which all objects smaller than `min_area` are excluded,
 i.e, their pixel values are set to `False`.
-We can then apply `skimage.measure.label` to the masked image:
+We can then apply `ski.measure.label` to the masked image:
 
 ```python
-object_mask = skimage.morphology.remove_small_objects(binary_mask,min_area)
-labeled_image, n = skimage.measure.label(object_mask,
+object_mask = ski.morphology.remove_small_objects(binary_mask,min_area)
+labeled_image, n = ski.measure.label(object_mask,
                                          connectivity=connectivity, return_num=True)
 ```
 
@@ -715,11 +713,11 @@ the `enhanced_connected_component` as follows:
 ```python
 def enhanced_connected_components(filename, sigma=1.0, t=0.5, connectivity=2, min_area=0):
     image = iio.imread(filename)
-    gray_image = skimage.color.rgb2gray(image)
-    blurred_image = skimage.filters.gaussian(gray_image, sigma=sigma)
+    gray_image = ski.color.rgb2gray(image)
+    blurred_image = ski.filters.gaussian(gray_image, sigma=sigma)
     binary_mask = blurred_image < t
-    object_mask = skimage.morphology.remove_small_objects(binary_mask,min_area)
-    labeled_image, count = skimage.measure.label(object_mask,
+    object_mask = ski.morphology.remove_small_objects(binary_mask,min_area)
+    labeled_image, count = ski.measure.label(object_mask,
                                                  connectivity=connectivity, return_num=True)
     return labeled_image, count
 ```
@@ -730,7 +728,7 @@ display the resulting labeled image:
 ```python
 labeled_image, count = enhanced_connected_components(filename="data/shapes-01.jpg", sigma=2.0, t=0.9,
                                                      connectivity=2, min_area=min_area)
-colored_label_image = skimage.color.label2rgb(labeled_image, bg_label=0)
+colored_label_image = ski.color.label2rgb(labeled_image, bg_label=0)
 
 fig, ax = plt.subplots()
 plt.imshow(colored_label_image)
@@ -777,7 +775,7 @@ Then we can create a `colored_area_image` where we assign each pixel value
 the area by indexing the `object_areas` with the label values in `labeled_image`.
 
 ```python
-object_areas = np.array([objf["area"] for objf in skimage.measure.regionprops(labeled_image)])
+object_areas = np.array([objf["area"] for objf in ski.measure.regionprops(labeled_image)])
 object_areas = np.insert(0,1,object_areas)
 colored_area_image = object_areas[labeled_image]
 
@@ -819,9 +817,9 @@ documentation](https://numpy.org/doc/stable/user/basics.indexing.html#advanced-i
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- We can use `skimage.measure.label` to find and label connected objects in an image.
-- We can use `skimage.measure.regionprops` to measure properties of labeled objects.
-- We can use `skimage.morphology.remove_small_objects` to mask small objects and remove artifacts from an image.
+- We can use `ski.measure.label` to find and label connected objects in an image.
+- We can use `ski.measure.regionprops` to measure properties of labeled objects.
+- We can use `ski.morphology.remove_small_objects` to mask small objects and remove artifacts from an image.
 - We can display the labeled image to view the objects coloured by label.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/08-connected-components.md
+++ b/episodes/08-connected-components.md
@@ -226,8 +226,8 @@ First, import the packages needed for this episode:
 ```python
 import imageio.v3 as iio
 import ipympl
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import skimage as ski
 
 %matplotlib widget

--- a/episodes/09-challenges.md
+++ b/episodes/09-challenges.md
@@ -85,7 +85,7 @@ the dark bacterial colonies.
 This is easier using a grayscale image, so we convert it here:
 
 ```python
-gray_bacteria = skimage.color.rgb2gray(bacteria_image)
+gray_bacteria = ski.color.rgb2gray(bacteria_image)
 
 # display the gray image
 fig, ax = plt.subplots()
@@ -97,7 +97,7 @@ plt.imshow(gray_bacteria, cmap="gray")
 Next, we blur the image and create a histogram:
 
 ```python
-blurred_image = skimage.filters.gaussian(gray_bacteria, sigma=1.0)
+blurred_image = ski.filters.gaussian(gray_bacteria, sigma=1.0)
 histogram, bin_edges = np.histogram(blurred_image, bins=256, range=(0.0, 1.0))
 fig, ax = plt.subplots()
 plt.plot(bin_edges[0:-1], histogram)
@@ -128,7 +128,7 @@ but how can we count how many there are?
 This requires connected component analysis:
 
 ```python
-labeled_image, count = skimage.measure.label(mask, return_num=True)
+labeled_image, count = ski.measure.label(mask, return_num=True)
 print(count)
 ```
 
@@ -137,9 +137,9 @@ the grayscale image:
 
 ```python
 # color each of the colonies a different color
-colored_label_image = skimage.color.label2rgb(labeled_image, bg_label=0)
+colored_label_image = ski.color.label2rgb(labeled_image, bg_label=0)
 # give our grayscale image rgb channels, so we can add the colored colonies
-summary_image = skimage.color.gray2rgb(gray_bacteria)
+summary_image = ski.color.gray2rgb(gray_bacteria)
 summary_image[mask] = colored_label_image[mask]
 
 # plot overlay
@@ -156,14 +156,14 @@ This is a good point to collect the lines above into a re-usable function:
 ```python
 def count_colonies(image_filename):
     bacteria_image = iio.imread(image_filename)
-    gray_bacteria = skimage.color.rgb2gray(bacteria_image)
-    blurred_image = skimage.filters.gaussian(gray_bacteria, sigma=1.0)
+    gray_bacteria = ski.color.rgb2gray(bacteria_image)
+    blurred_image = ski.filters.gaussian(gray_bacteria, sigma=1.0)
     mask = blurred_image < 0.2
-    labeled_image, count = skimage.measure.label(mask, return_num=True)
+    labeled_image, count = ski.measure.label(mask, return_num=True)
     print(f"There are {count} colonies in {image_filename}")
 
-    colored_label_image = skimage.color.label2rgb(labeled_image, bg_label=0)
-    summary_image = skimage.color.gray2rgb(gray_bacteria)
+    colored_label_image = ski.color.label2rgb(labeled_image, bg_label=0)
+    summary_image = ski.color.gray2rgb(gray_bacteria)
     summary_image[mask] = colored_label_image[mask]
     fig, ax = plt.subplots()
     plt.imshow(summary_image)

--- a/episodes/09-challenges.md
+++ b/episodes/09-challenges.md
@@ -63,12 +63,12 @@ so that it can be applied conveniently to any image file.
 First, let's work through the process for one image:
 
 ```python
-import numpy as np
 import imageio.v3 as iio
-import skimage.color
-import skimage.filters
-import matplotlib.pyplot as plt
 import ipympl
+import matplotlib.pyplot as plt
+import numpy as np
+import skimage as ski
+
 %matplotlib widget
 
 bacteria_image = iio.imread(uri="data/colonies-01.tif")

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -101,15 +101,16 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 
    ```python
    import imageio.v3 as iio
-   from skimage import transform
    import matplotlib.pyplot as plt
+   import skimage as ski
+
    %matplotlib widget
 
    # load an image
    image = iio.imread(uri='data/colonies-01.tif')
 
    # rotate it by 45 degrees
-   rotated = transform.rotate(image=image, angle=45)
+   rotated = ski.transform.rotate(image=image, angle=45)
 
    # display the original image and its rotated version side by side
    fig, ax = plt.subplots(1, 2)


### PR DESCRIPTION
Dear @datacarpentry/image-processing-curriculum-maintainers,

As per the Aug 30 meeting with @tobyhodges and @datacarpentry/curriculum-advisors-image, this PR:

* Closes #295;
* Updates (removes) some sentences which don't hold anymore, now that we have lazy loading (modules are loaded only when needed);
* Reorders imports alphabetically at the top of each episode.

Best,
Marianne

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
