### PR TITLE
use spoiler class divs

### DIFF
--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -115,7 +115,7 @@ from skimage.draw import disk  # form 3, load only the disk function
 import numpy as np             # form 4, load all of numpy into an object called np
 ```
 
-::::::::::::::  solution
+::::::::::::::::  spoiler
 
 ## Further Explanation
 

--- a/episodes/08-connected-components.md
+++ b/episodes/08-connected-components.md
@@ -321,11 +321,7 @@ plt.imshow(labeled_image)
 plt.axis("off");
 ```
 
-:::::::::::::: {.empty-div style="margin-bottom: 50px"}
-<!-- This div is intentionally empty to allow the solution to float alone -->
-::::::::::::::
-
-::::::::::::::  solution
+::::::::::::::::  spoiler
 
 ## Color mappings
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -70,11 +70,7 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 
 3. Open a Jupyter notebook:
 
-   :::::::::::::: {.empty-div style="margin-bottom: 50px"}
-   <!-- This div is intentionally empty to allow the solution to float alone -->
-   ::::::::::::::
-
-   ::::::::::::::  solution
+   ::::::::::::::::  spoiler
 
    ## Instructions for Linux \& Mac
 
@@ -83,7 +79,7 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 
    :::::::::::::::::::::::::
 
-   ::::::::::::::  solution
+   ::::::::::::::::  spoiler
 
    ## Instructions for Windows
 
@@ -119,11 +115,7 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 
    Upon execution of the cell, a figure with two images should be displayed in an interactive widget. When hovering over the images with the mouse pointer, the pixel coordinates and colour values are displayed below the image.
 
-   :::::::::::::: {.empty-div style="margin-bottom: 50px"}
-   <!-- This div is intentionally empty to allow the solution to float alone -->
-   ::::::::::::::
-
-   ::::::::::::::  solution
+   ::::::::::::::::  spoiler
 
    ## Running Cells in a Notebook
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

This switches floating solution divs for the `spoiler` class introduced in the recent release of the lesson infrastructure

_If any relevant discussions have taken place elsewhere, please provide links to these._

See https://github.com/carpentries/sandpaper/pull/502#issuecomment-1698203526 for an example of a spoiler class div in action.