### PR TITLE
More library name formatting

### DIFF
--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -180,7 +180,7 @@ so you might be asking why we don't use it here.
 Actually, `skimage.io.imread()` uses `iio.imread()` internally when loading an image into Python.
 It is certainly something you may use as you see fit in your own code.
 In this lesson, we use the imageio library to read or write (save) images,
-while `skimage` is dedicated to performing operations on the images.
+while scikit-image is dedicated to performing operations on the images.
 Using imageio gives us more flexibility, especially when it comes to
 handling metadata.
 

--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -166,8 +166,8 @@ With that taken care of,
 let's load our image data from disk using
 the `imread` function from the `imageio.v3` module and display it using
 the `imshow` function from the `matplotlib.pyplot` module.
-`imageio` is a Python library for reading and writing image data.
-`imageio.v3` is specifying that we want to use version 3 of `imageio`. This
+Imageio is a Python library for reading and writing image data.
+`imageio.v3` is specifying that we want to use version 3 of imageio. This
 version has the benefit of supporting nD (multidimensional) image data
 natively (think of volumes, movies).
 
@@ -179,9 +179,9 @@ The scikit-image library has its own function to read an image,
 so you might be asking why we don't use it here.
 Actually, `skimage.io.imread()` uses `iio.imread()` internally when loading an image into Python.
 It is certainly something you may use as you see fit in your own code.
-In this lesson, we use the `imageio` library to read or write (save) images,
+In this lesson, we use the imageio library to read or write (save) images,
 while `skimage` is dedicated to performing operations on the images.
-Using `imageio` gives us more flexibility, especially when it comes to
+Using imageio gives us more flexibility, especially when it comes to
 handling metadata.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -256,9 +256,9 @@ We will start by reading the image and displaying it.
 
 :::::::::::::::::::::::::::::::::::::::::  callout
 
-## Loading images with `imageio`: Read-only arrays
+## Loading images with imageio: Read-only arrays
 
-When loading an image with `imageio`, in certain situations the image is stored in a read-only array. If you attempt to manipulate the pixels in a read-only array, you will receive an error message `ValueError: assignment destination is read-only`. In order to make the image array writeable, we can create a copy with `image = np.array(image)` before manipulating the pixel values.
+When loading an image with imageio, in certain situations the image is stored in a read-only array. If you attempt to manipulate the pixels in a read-only array, you will receive an error message `ValueError: assignment destination is read-only`. In order to make the image array writeable, we can create a copy with `image = np.array(image)` before manipulating the pixel values.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -359,7 +359,7 @@ pass `plugin="pillow"`. If the backend is not specified explicitly, `iio.imread(
 
 :::::::::::::::::::::::::::::::::::::::::  callout
 
-## Loading images with `imageio`: Pixel type and depth
+## Loading images with imageio: Pixel type and depth
 
 When loading an image with `mode="L"`, the pixel values are stored as 8-bit integer numbers that can take values in the range 0-255. However, pixel values may also be stored with other types and ranges. For example, some scikit-image functions return the pixel values as floating point numbers in the range 0-1. The type and range of the pixel values are important for the colorscale when plotting, and for masking and thresholding images as we will see later in the lesson. If you are unsure about the type of the pixel values, you can inspect it with `print(image.dtype)`. For the example above, you should find that it is `dtype('uint8')` indicating 8-bit integer numbers.
 
@@ -393,7 +393,7 @@ range 0-255 of an 8-bit pixel). The results should look like this:
 
 ## Solution
 
-First, load the image file `data/sudoku.png` as a grayscale image. Remember that we use `image = np.array(image)` to create a copy of the image array because `imageio` returns a non-writeable image.
+First, load the image file `data/sudoku.png` as a grayscale image. Remember that we use `image = np.array(image)` to create a copy of the image array because `imageio.imread` returns a non-writeable image.
 
 ```python
 


### PR DESCRIPTION
_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

This adjusts references to imageio in the lesson to fit the formatting convention we chose for other libraries in #288, based on how imageio is mentioned in the project's own documentation. It also fixes one reference to scikit-image that I missed in my first pass.

_If any relevant discussions have taken place elsewhere, please provide links to these._

See https://github.com/datacarpentry/image-processing/pull/288#issuecomment-1721043612 for @mkcor's original comment that raised this.
