### PR TITLE
Improve layout of table in image basics

### DIFF
--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -1050,15 +1050,12 @@ the metadata of your images.
 The following table summarises the characteristics of the BMP, JPEG, and TIFF
 image formats:
 
-| Format                                  | Compression   | Metadata   | Advantages             | Disadvantages                              |
-| :-------------------------------------- | :------------ | :--------- | :--------------------- | :----------------------------------------- |
-| BMP                                     | None          | None       | Universally viewable,  | Large file sizes                           |
-|                                         |               |            | high quality           |                                            |
-| JPEG                                    | Lossy         | Yes        | Universally viewable,  | Detail may be lost                         |
-|                                         |               |            | smaller file size      |                                            |
-| PNG                                     | Lossless      | [Yes](https://www.w3.org/TR/PNG/#11keywords)           | Universally viewable, [open standard](https://www.w3.org/TR/PNG/), smaller file size | Metadata less flexible than TIFF, RGB only |
-| TIFF                                    | None, lossy,  | Yes        | High quality or        | Not universally viewable                   |
-|                                         | or lossless   |            | smaller file size      |                                            |
+| Format           | Compression   | Metadata   | Advantages             | Disadvantages           |
+| :--------------- | :------------ | :--------- | :--------------------- | :---------------------  |
+| BMP              | None          | None       | Universally viewable, high quality       | Large file sizes         |
+| JPEG             | Lossy         | Yes        | Universally viewable, smaller file size  | Detail may be lost       |
+| PNG              | Lossless      | [Yes](https://www.w3.org/TR/PNG/#11keywords)          | Universally viewable, [open standard](https://www.w3.org/TR/PNG/), smaller file size | Metadata less flexible than TIFF, RGB only |
+| TIFF             | None, lossy, or lossless  | Yes        | High quality or smaller file size        | Not universally viewable     |
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 


### PR DESCRIPTION
The table at the end of the 'image basics' episode currently splits some file types across multiple lines (with different shading grey/white) e.g. BMP + JPEG. This makes it a bit difficult to read at a glance.

![Screenshot (1)](https://github.com/datacarpentry/image-processing/assets/24316371/997a7ed1-6b4a-4e0b-924f-7f01577040ba)

This PR makes each file format its own line + adjusts the column widths to make it more readable:

![Screenshot (2)](https://github.com/datacarpentry/image-processing/assets/24316371/ef3cedcd-af66-4041-a5c3-b65a2984b7fe)
