### PR TITLE
corrected anaconda download link

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -17,7 +17,7 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 ## Software
 
 1. Download and install the latest [Anaconda
-   distribution](https://www.anaconda.com/distribution/) for your
+   distribution](https://www.anaconda.com/download/) for your
    operating system. Make sure to choose the Python 3 version (as
    opposed to the one with Python 2). If you wish to use an existing
    installation, be sure to upgrade your scikit-image to at least 0.19.


### PR DESCRIPTION
Current download URL for Anaconda returns a 404 error. Corrected with updated download page.
