### PR TITLE
Comparing lossless versus lossy compression for Windows users

### DIFF
--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -893,7 +893,7 @@ Apply lossless compression to this image by executing the following command:
 This command tells the computer to create a new compressed file,
 `ws.zip`, from the original bitmap image.
 Execute a similar command on the tree JPEG file: `zip tree.zip tree.jpg` 
-(`Compress-Archive tree.jpg jpg.zip` with PowerShell).
+(`Compress-Archive tree.jpg tree.zip` with PowerShell).
 
 Having created the compressed file,
 use the `ls -al` command (`dir` with PowerShell) to display the contents of the directory.

--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -896,7 +896,7 @@ Execute a similar command on the tree JPEG file: `zip tree.zip tree.jpg`
 (`Compress-Archive tree.jpg tree.zip` with PowerShell).
 
 Having created the compressed file,
-use the `ls -al` command (`dir` with PowerShell) to display the contents of the directory.
+use the `ls -l` command (`dir` with PowerShell) to display the contents of the directory.
 How big are the compressed files?
 How do those compare to the size of `ws.bmp` and `tree.jpg`?
 What can you conclude from the relative sizes?

--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -881,20 +881,22 @@ two orders of magnitude smaller than the bitmap version.
 ## Comparing lossless versus lossy compression (optional, not included in timing)
 
 Let us see a hands-on example of lossless versus lossy compression.
-Once again, open a terminal and navigate to the `data/` directory.
+Open a terminal (or Windows PowerShell) and navigate to the `data/` directory.
 The two output images, `ws.bmp` and `ws.jpg`, should still be in the directory,
 along with another image, `tree.jpg`.
 
 We can apply lossless compression to any file by using the `zip` command.
 Recall that the `ws.bmp` file contains 75,000,054 bytes.
 Apply lossless compression to this image by executing the following command:
-`zip ws.zip ws.bmp`.
+`zip ws.zip ws.bmp` 
+(`Compress-Archive ws.bmp ws.zip` with PowerShell).
 This command tells the computer to create a new compressed file,
 `ws.zip`, from the original bitmap image.
-Execute a similar command on the tree JPEG file: `zip tree.zip tree.jpg`.
+Execute a similar command on the tree JPEG file: `zip tree.zip tree.jpg` 
+(`Compress-Archive tree.jpg jpg.zip` with PowerShell).
 
 Having created the compressed file,
-use the `ls -al` command to display the contents of the directory.
+use the `ls -al` command (`dir` with PowerShell) to display the contents of the directory.
 How big are the compressed files?
 How do those compare to the size of `ws.bmp` and `tree.jpg`?
 What can you conclude from the relative sizes?

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -189,8 +189,8 @@ Images may appear the same size in jupyter,
 but you can see the size difference by comparing the scales for each.
 You can also see the differnce in file storage size on disk by
 hovering your mouse cursor over the original
-and the new file in the jupyter file browser, using `ls -l` in your shell,
-or the OS file browser if it is configured to show file sizes.
+and the new file in the jupyter file browser, using `ls -l` in your shell 
+(`dir` with Windows PowerShell), or the OS file browser if it is configured to show file sizes.
 
 :::::::::::::::  solution
 

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -187,10 +187,10 @@ Don't forget to use `fig, ax = plt.subplots()` so you don't overwrite
 the first image with the second.
 Images may appear the same size in jupyter,
 but you can see the size difference by comparing the scales for each.
-You can also see the differnce in file storage size on disk by
+You can also see the difference in file storage size on disk by
 hovering your mouse cursor over the original
-and the new file in the jupyter file browser, using `ls -l` in your shell 
-(`dir` with Windows PowerShell), or the OS file browser if it is configured to show file sizes.
+and the new files in the Jupyter file browser, using `ls -l` in your shell 
+(`dir` with Windows PowerShell), or viewing file sizes in the OS file browser if it is configured so.
 
 :::::::::::::::  solution
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -132,4 +132,8 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 
    :::::::::::::::::::::::::
 
+5. A small number of exercises will require you to run commands in a terminal. Windows users should 
+use PowerShell for this. PowerShell is probably installed by default but if not you should
+[download and install](https://apps.microsoft.com/detail/9MZ1SNWT0N5D?hl=en-eg&gl=EG) it.
+
 [figshare-data]: https://figshare.com/articles/dataset/Data_Carpentry_Image_Processing_Data_beta_/19260677


### PR DESCRIPTION
The _Comparing lossless versus lossy compression_ exercise does not work for Windows users who do not have a bash terminal with zip installed (I tried Git for Windows but zip not included). Here I've added a potential command line solution using Windows PowerShell.