### PR TITLE
Keeping low intensity pixels

### DIFF
--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -416,9 +416,9 @@ Finally, display the original and modified images. Note that we have to specify 
 
 ```python
 fig, ax = plt.subplots()
-plt.imshow(sudoku, cmap="gray", vmin=0, vmax=255)
-fig, ax = plt.subplots()
-plt.imshow(sudoku_gray_background, cmap="gray", vmin=0, vmax=255)
+fig, ax = plt.subplots(ncols=2)
+ax[0].imshow(sudoku, cmap="gray", vmin=0, vmax=255)
+ax[1].imshow(sudoku_gray_background, cmap="gray", vmin=0, vmax=255)
 ```
 
 :::::::::::::::::::::::::

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -389,7 +389,7 @@ range 0-255 of an 8-bit pixel). The results should look like this:
 ![](fig/sudoku-gray.png){alt='Modified Su-Do-Ku puzzle'}
 
 *Hint: the `cmap`, `vmin`, and `vmax` parameters of `matplotlib.pyplot.imshow`
-will be needed to display the modified image as desired. See the [matplotlib
+will be needed to display the modified image as desired. See the [Matplotlib
 documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html) 
 for more details on `cmap`, `vmin`, and `vmax`.*
 

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -388,10 +388,10 @@ range 0-255 of an 8-bit pixel). The results should look like this:
 
 ![](fig/sudoku-gray.png){alt='Modified Su-Do-Ku puzzle'}
 
-*Hint: the 'cmap', 'vmin' and 'vmax' parameters of 'matplotlib.pyplot.imshow'
+*Hint: the `cmap`, `vmin` and `vmax` parameters of 'matplotlib.pyplot.imshow'
 will be needed to display the modified image as desired. See the [matplotlib
 documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html) 
-for more details on 'cmap', 'vmin' and 'vmax'.*
+for more details on `cmap`, `vmin` and `vmax`.*
 
 :::::::::::::::  solution
 

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -391,7 +391,7 @@ range 0-255 of an 8-bit pixel). The results should look like this:
 *Hint: the `cmap`, `vmin`, and `vmax` parameters of `matplotlib.pyplot.imshow`
 will be needed to display the modified image as desired. See the [matplotlib
 documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html) 
-for more details on `cmap`, `vmin` and `vmax`.*
+for more details on `cmap`, `vmin`, and `vmax`.*
 
 :::::::::::::::  solution
 

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -379,7 +379,8 @@ The file `data/sudoku.png` is an RGB image of a sudoku puzzle:
 
 ![](data/sudoku.png){alt='Su-Do-Ku puzzle'}
 
-Your task is to turn all of the bright pixels in the image to a
+Your task is to load the image in grayscale format and turn all of 
+the bright pixels in the image to a
 light gray colour. In other words, mask the bright pixels that have
 a pixel value greater than, say, 192 and set their value to 192 (the
 value 192 is chosen here because it corresponds to 75% of the
@@ -387,31 +388,37 @@ range 0-255 of an 8-bit pixel). The results should look like this:
 
 ![](fig/sudoku-gray.png){alt='Modified Su-Do-Ku puzzle'}
 
-*Hint: this is an instance where it is helpful to load the image in grayscale format.*
+*Hint: the 'cmap', 'vmin' and 'vmax' parameters of 'matplotlib.pyplot.imshow'
+will be needed to display the modified image as desired. See the [matplotlib
+documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html) 
+for more details on 'cmap', 'vmin' and 'vmax'.*
 
 :::::::::::::::  solution
 
 ## Solution
 
-First, load the image file `data/sudoku.png` as a grayscale image. Remember that we use `image = np.array(image)` to create a copy of the image array because `imageio.imread` returns a non-writeable image.
+First, load the image file `data/sudoku.png` as a grayscale image. 
+Note we may want to create a copy of the image array to avoid modifying our original variable and 
+also because `imageio.imread` sometimes returns a non-writeable image.
 
 ```python
-
-sudoku = iio.imread(uri="data/sudoku.png")
+sudoku = iio.imread(uri="data/sudoku.png", mode="L")
+sudoku_gray_background = sudoku.copy()
 ```
 
 Then change all bright pixel values greater than 192 to 192:
 
 ```python
-sudoku = sudoku.copy()
-sudoku[sudoku > 125] = 125
+sudoku_gray_background[sudoku_gray_background > 192] = 192
 ```
 
-Finally, display the modified image. Note that we have to specify `vmin=0` and `vmax=255` as the range of the colorscale because it would otherwise automatically adjust to the new range 0-192.
+Finally, display the original and modified images. Note that we have to specify `vmin=0` and `vmax=255` as the range of the colorscale because it would otherwise automatically adjust to the new range 0-192.
 
 ```python
 fig, ax = plt.subplots()
-plt.imshow(sudoku, cmap="gray", vmin=0, vmax=1)
+plt.imshow(sudoku, cmap="gray", vmin=0, vmax=255)
+fig, ax = plt.subplots()
+plt.imshow(sudoku_gray_background, cmap="gray", vmin=0, vmax=255)
 ```
 
 :::::::::::::::::::::::::

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -412,7 +412,7 @@ Then change all bright pixel values greater than 192 to 192:
 sudoku_gray_background[sudoku_gray_background > 192] = 192
 ```
 
-Finally, display the original and modified images. Note that we have to specify `vmin=0` and `vmax=255` as the range of the colorscale because it would otherwise automatically adjust to the new range 0-192.
+Finally, display the original and modified images side by side. Note that we have to specify `vmin=0` and `vmax=255` as the range of the colorscale because it would otherwise automatically adjust to the new range 0-192.
 
 ```python
 fig, ax = plt.subplots()

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -399,7 +399,7 @@ for more details on `cmap`, `vmin` and `vmax`.*
 
 First, load the image file `data/sudoku.png` as a grayscale image. 
 Note we may want to create a copy of the image array to avoid modifying our original variable and 
-also because `imageio.imread` sometimes returns a non-writeable image.
+also because `imageio.v3.imread` sometimes returns a non-writeable image.
 
 ```python
 sudoku = iio.imread(uri="data/sudoku.png", mode="L")

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -403,7 +403,7 @@ also because `imageio.imread` sometimes returns a non-writeable image.
 
 ```python
 sudoku = iio.imread(uri="data/sudoku.png", mode="L")
-sudoku_gray_background = sudoku.copy()
+sudoku_gray_background = np.array(sudoku)
 ```
 
 Then change all bright pixel values greater than 192 to 192:

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -388,7 +388,7 @@ range 0-255 of an 8-bit pixel). The results should look like this:
 
 ![](fig/sudoku-gray.png){alt='Modified Su-Do-Ku puzzle'}
 
-*Hint: the `cmap`, `vmin` and `vmax` parameters of 'matplotlib.pyplot.imshow'
+*Hint: the `cmap`, `vmin` and `vmax` parameters of `matplotlib.pyplot.imshow`
 will be needed to display the modified image as desired. See the [matplotlib
 documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html) 
 for more details on `cmap`, `vmin` and `vmax`.*

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -388,7 +388,7 @@ range 0-255 of an 8-bit pixel). The results should look like this:
 
 ![](fig/sudoku-gray.png){alt='Modified Su-Do-Ku puzzle'}
 
-*Hint: the `cmap`, `vmin` and `vmax` parameters of `matplotlib.pyplot.imshow`
+*Hint: the `cmap`, `vmin`, and `vmax` parameters of `matplotlib.pyplot.imshow`
 will be needed to display the modified image as desired. See the [matplotlib
 documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html) 
 for more details on `cmap`, `vmin` and `vmax`.*


### PR DESCRIPTION
I've made a few changes to this exercise to either make it easier for participants to follow or to correct some minor mistakes.
**Instructions**
1. Tell participants to load as grayscale rather than as a hint.
2. Hint now to look at `cmap`, `vmin` and `vmax` arguments for `matplotlib.pyplot.imshow` as these are needed and `vmin` and `vmax` havn't been introduced yet.

**Solution**
1. There are a few discrepancies/mistakes between the text and the code. Specifically the code dosn't load in grayscale, uses a different threshold value and incorrect vmin and vmax. 
2. When copying the image array I assign to a new variable and display both original and modified images at the end. I think this is nice but not essential.