### PR TITLE
Problem with solution for thresholding exercise

### DIFF
--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -228,7 +228,8 @@ you think would be a good value for the threshold `t`?
 The histogram for the `data/shapes-02.jpg` image can be shown with
 
 ```python
-gray_shapes = iio.imread(uri="data/shapes-02.jpg", mode="L")
+shapes = iio.imread(uri="data/shapes-02.jpg")
+gray_shapes = ski.color.rgb2gray(shapes)
 histogram, bin_edges = np.histogram(gray_shapes, bins=256, range=(0.0, 1.0))
 
 fig, ax = plt.subplots()


### PR DESCRIPTION
The solution dosnt work as expected for me as loading as grayscale with `mode="L"` does not necessarily return an image in the range 0-1. I've changed to convert to grayscale after loading with `ski.color.rgb2gray` which returns a single channel image with 0-1 range.
