### PR TITLE
Automated thresholding suggestions

### DIFF
--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -657,10 +657,10 @@ The output of the improved program does illustrate that the white circles
 and labels were skewing our root mass ratios:
 
 ```output
-data\trial-016.jpg,0.046250166223404256
-data\trial-020.jpg,0.05886968085106383
-data\trial-216.jpg,0.13712117686170214
-data\trial-293.jpg,0.13190342420212767
+data/trial-016.jpg,0.046250166223404256
+data/trial-020.jpg,0.05886968085106383
+data/trial-216.jpg,0.13712117686170214
+data/trial-293.jpg,0.13190342420212767
 ```
 
 Here are the binary images produced by the additional thresholding.

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -347,14 +347,27 @@ plt.xlim(0, 1.0)
 
 ![](fig/maize-root-cluster-histogram.png){alt='Grayscale histogram of the maize root image'}
 
-The histogram has a significant peak around 0.2 and then a broader "hill" around 0.6 followed by a smaller peak near 1.0. Looking at the grayscale image, we can identify the lower peak at 0.2 as the background and the larger pixel values as the foreground, but it is not so obvious what the threshold should be.
+The histogram has a significant peak around 0.2 and then a broader "hill" around 0.6 followed by a 
+smaller peak near 1.0. Looking at the grayscale image, we can identify the lower peak at 0.2 as the
+background and the broader peak as the foreground.
 Thus, this image is a good candidate for thresholding with Otsu's method.
 The mathematical details of how this works are complicated (see
 [the scikit-image documentation](https://scikit-image.org/docs/dev/api/skimage.filters.html#threshold-otsu)
 if you are interested),
-but the outcome is that Otsu's method finds a threshold value between the two peaks of a grayscale histogram which might correspond well to the foreground and background depending the data and application.
+but the outcome is that Otsu's method finds a threshold value between the two peaks of a grayscale
+histogram which might correspond well to the foreground and background depending on the data and 
+application.
+
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
-The histogram of the maize root image may prompt questions from learners about the interpretation of the peaks and the broader region around 0.6. The focus here is on the separation of background and foreground pixel values. We note that Otsu's method does not work well for the image with the shapes used earlier in this episode, as the foreground pixel values are more distributed. These examples could be augmented by a discussion of unimodal, bimodal, and multimodal histograms. While these points can lead to fruitful discussions, the text in this episode attempts to reduce cognitive load and deliberately simplifies the discussion.
+
+The histogram of the maize root image may prompt questions from learners about the interpretation 
+of the peaks and the broader region around 0.6. The focus here is on the separation of background 
+and foreground pixel values. We note that Otsu's method does not work well 
+for the image with the shapes used earlier in this episode, as the foreground pixel values are more 
+distributed. These examples could be augmented by a discussion of unimodal, bimodal, and multimodal
+histograms. While these points can lead to fruitful discussions, the text in this episode attempts 
+to reduce cognitive load and deliberately simplifies the discussion.
+
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 The `ski.filters.threshold_otsu()` function can be used to determine
@@ -632,7 +645,7 @@ def enhanced_root_mass(filename, sigma):
     t = ski.filters.threshold_otsu(blurred_image[binary_mask])
     
     # update binary mask to identify pixels which are both less than 0.95 and greater than t
-    binary_mask = binary_mask & (blurred_image > t)
+    binary_mask = (blurred_image < 0.95) & (blurred_image > t)
 
     # determine root mass ratio
     root_pixels = np.count_nonzero(binary_mask)
@@ -674,6 +687,7 @@ The `&` operator above means that we have defined a logical AND statement. This 
 Knowing how to construct this kind of logical operation can be very helpful in image processing. The University of Minnesota Library's [guide to Boolean operators](https://libguides.umn.edu/BooleanOperators) is a good place to start if you want to learn more.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
 Here are the binary images produced by the additional thresholding.
 Note that we have not completely removed the offending white pixels.
 Outlines still remain.

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -678,7 +678,7 @@ data/trial-293.jpg,0.13190342420212767
 
 The `&` operator above means that we have defined a logical AND statement. This combines the two tests of pixel intensities in the blurred image such that both must be true for a pixel's position to be set to `True` in the resulting mask.
 
-| Result of `t < blurred_image` | Result of `blurred_image < 0.95 | Resulting value in `binary_mask` |
+| Result of `t < blurred_image` | Result of `blurred_image < 0.95` | Resulting value in `binary_mask` |
 |----------|---------|---------|
 | False | True | False |
 | True | False | False |

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -352,8 +352,7 @@ Thus, this image is a good candidate for thresholding with Otsu's method.
 The mathematical details of how this works are complicated (see
 [the scikit-image documentation](https://scikit-image.org/docs/dev/api/skimage.filters.html#threshold-otsu)
 if you are interested),
-but the outcome is that Otsu's method finds a threshold value between
-the two peaks of a grayscale histogram.
+but the outcome is that Otsu's method finds a threshold value between the two peaks of a grayscale histogram which might correspond well to the foreground and background depending the data and application.
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
 The histogram of the maize root image may prompt questions from learners about the interpretation of the peaks and the broader region around 0.6. The focus here is on the separation of background and foreground pixel values. We note that Otsu's method does not work well for the image with the shapes used earlier in this episode, as the foreground pixel values are more distributed. These examples could be augmented by a discussion of unimodal, bimodal, and multimodal histograms. While these points can lead to fruitful discussions, the text in this episode attempts to reduce cognitive load and deliberately simplifies the discussion.
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -633,7 +632,7 @@ def enhanced_root_mass(filename, sigma):
     t = ski.filters.threshold_otsu(blurred_image[binary_mask])
     
     # update binary mask to identify pixels which are both less than 0.95 and greater than t
-    binary_mask = np.logical_and(binary_mask, blurred_image > t)
+    binary_mask = binary_mask & (blurred_image > t)
 
     # determine root mass ratio
     root_pixels = np.count_nonzero(binary_mask)

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -348,8 +348,8 @@ plt.xlim(0, 1.0)
 ![](fig/maize-root-cluster-histogram.png){alt='Grayscale histogram of the maize root image'}
 
 The histogram has a significant peak around 0.2 and then a broader "hill" around 0.6 followed by a 
-smaller peak near 1.0. Looking at the grayscale image, we can identify the peak at 0.2 as the
-background and the broader peak as the foreground.
+smaller peak near 1.0. Looking at the grayscale image, we can identify the peak at 0.2 with the
+background and the broader peak with the foreground.
 Thus, this image is a good candidate for thresholding with Otsu's method.
 The mathematical details of how this works are complicated (see
 [the scikit-image documentation](https://scikit-image.org/docs/dev/api/skimage.filters.html#threshold-otsu)

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -364,8 +364,8 @@ The histogram of the maize root image may prompt questions from learners about t
 of the peaks and the broader region around 0.6. The focus here is on the separation of background 
 and foreground pixel values. We note that Otsu's method does not work well 
 for the image with the shapes used earlier in this episode, as the foreground pixel values are more 
-distributed. These examples could be augmented by a discussion of unimodal, bimodal, and multimodal
-histograms. While these points can lead to fruitful discussions, the text in this episode attempts 
+distributed. These examples could be augmented with a discussion of unimodal, bimodal, and multimodal
+histograms. While these points can lead to fruitful considerations, the text in this episode attempts 
 to reduce cognitive load and deliberately simplifies the discussion.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -616,9 +616,8 @@ and label from the image before applying Otsu's method.
 ## Solution
 
 We can apply a simple binary thresholding with a threshold
-`t=0.95` to remove the label and circle from the image. We use the
-binary mask to set the pixels in the blurred image to zero
-(black).
+`t=0.95` to remove the label and circle from the image. We can then use the
+binary mask to calculate the Otsu threshold without the pixels from the label and circle.
 
 ```python
 def enhanced_root_mass(filename, sigma):
@@ -631,20 +630,21 @@ def enhanced_root_mass(filename, sigma):
 
     # perform binary thresholding to mask the white label and circle
     binary_mask = blurred_image < 0.95
-    # use the mask to remove the circle and label from the blurred image
-    blurred_image[~binary_mask] = 0
-
-    # perform automatic thresholding to produce a binary image
-    t = ski.filters.threshold_otsu(blurred_image)
-    binary_mask = blurred_image > t
+    
+    # perform automatic thresholding using only the pixels with value True in the binary mask
+    t = ski.filters.threshold_otsu(blurred_image[binary_mask])
+    
+    # update binary mask to identify pixels which are both less than 0.95 and greater than t
+    binary_mask = np.logical_and(binary_mask, blurred_image > t)
 
     # determine root mass ratio
-    rootPixels = np.count_nonzero(binary_mask)
+    root_pixels = np.count_nonzero(binary_mask)
     w = binary_mask.shape[1]
     h = binary_mask.shape[0]
-    density = rootPixels / (w * h)
+    density = root_pixels / (w * h)
 
     return density
+
 
 all_files = glob.glob("data/trial-*.jpg")
 for filename in all_files:
@@ -657,10 +657,10 @@ The output of the improved program does illustrate that the white circles
 and labels were skewing our root mass ratios:
 
 ```output
-data/trial-016.jpg,0.045935837765957444
-data/trial-020.jpg,0.058800033244680854
-data/trial-216.jpg,0.13705003324468085
-data/trial-293.jpg,0.13164461436170213
+data\trial-016.jpg,0.046250166223404256
+data\trial-020.jpg,0.05886968085106383
+data\trial-216.jpg,0.13712117686170214
+data\trial-293.jpg,0.13190342420212767
 ```
 
 Here are the binary images produced by the additional thresholding.

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -347,18 +347,16 @@ plt.xlim(0, 1.0)
 
 ![](fig/maize-root-cluster-histogram.png){alt='Grayscale histogram of the maize root image'}
 
-The histogram has a significant peak around 0.2, and a second,
-shallower peak near 0.6.
+The histogram has a significant peak around 0.2 and then a broader "hill" around 0.6 followed by a smaller peak near 1.0. Looking at the grayscale image, we can identify the lower peak at 0.2 as the background and the larger pixel values as the foreground, but it is not so obvious what the threshold should be.
 Thus, this image is a good candidate for thresholding with Otsu's method.
 The mathematical details of how this works are complicated (see
 [the scikit-image documentation](https://scikit-image.org/docs/dev/api/skimage.filters.html#threshold-otsu)
 if you are interested),
 but the outcome is that Otsu's method finds a threshold value between
 the two peaks of a grayscale histogram.
-Note there is a third peak very close to 1.0 which corresponds to the white label and disk on the 
-left hand side of the image. It would be a good idea to remove these white pixels 
-before calculating the Otsu threshold. We will discuss how to do this later in the episode but for 
-now we will continue without removing them.
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
+The histogram of the maize root image may prompt questions from learners about the interpretation of the peaks and the broader region around 0.6. The focus here is on the separation of background and foreground pixel values. We note that Otsu's method does not work well for the image with the shapes used earlier in this episode, as the foreground pixel values are more distributed. These examples could be augmented by a discussion of unimodal, bimodal, and multimodal histograms. While these points can lead to fruitful discussions, the text in this episode attempts to reduce cognitive load and deliberately simplifies the discussion.
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 The `ski.filters.threshold_otsu()` function can be used to determine
 the threshold automatically via Otsu's method.
@@ -662,7 +660,21 @@ data/trial-020.jpg,0.05886968085106383
 data/trial-216.jpg,0.13712117686170214
 data/trial-293.jpg,0.13190342420212767
 ```
+:::::::::::::::::::::::::::::::::::::::::: spoiler
 
+### What is `&` doing in the example above?
+
+The `&` operator above means that we have defined a logical AND statement. This combines the two tests of pixel intensities in the blurred image such that both must be true for a pixel's position to be set to `True` in the resulting mask.
+
+| Result of `t < blurred_image` | Result of `blurred_image < 0.95 | Resulting value in `binary_mask` |
+|----------|---------|---------|
+| False | True | False |
+| True | False | False |
+| True | True | True |
+ 
+Knowing how to construct this kind of logical operation can be very helpful in image processing. The University of Minnesota Library's [guide to Boolean operators](https://libguides.umn.edu/BooleanOperators) is a good place to start if you want to learn more.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 Here are the binary images produced by the additional thresholding.
 Note that we have not completely removed the offending white pixels.
 Outlines still remain.

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -348,7 +348,7 @@ plt.xlim(0, 1.0)
 ![](fig/maize-root-cluster-histogram.png){alt='Grayscale histogram of the maize root image'}
 
 The histogram has a significant peak around 0.2 and then a broader "hill" around 0.6 followed by a 
-smaller peak near 1.0. Looking at the grayscale image, we can identify the lower peak at 0.2 as the
+smaller peak near 1.0. Looking at the grayscale image, we can identify the peak at 0.2 as the
 background and the broader peak as the foreground.
 Thus, this image is a good candidate for thresholding with Otsu's method.
 The mathematical details of how this works are complicated (see

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -348,13 +348,16 @@ plt.xlim(0, 1.0)
 ![](fig/maize-root-cluster-histogram.png){alt='Grayscale histogram of the maize root image'}
 
 The histogram has a significant peak around 0.2, and a second,
-smaller peak very near 1.0.
+shallower peak near 0.6.
 Thus, this image is a good candidate for thresholding with Otsu's method.
 The mathematical details of how this works are complicated (see
 [the scikit-image documentation](https://scikit-image.org/docs/dev/api/skimage.filters.html#threshold-otsu)
 if you are interested),
 but the outcome is that Otsu's method finds a threshold value between
 the two peaks of a grayscale histogram.
+Note there is a third peak very close to 1.0 which corresponds to the white label and disk on the 
+left hand side of the image. It would be a good idea to crop the image to remove these white pixels 
+before calculating the Otsu threshold but for now we will continue without doing this.
 
 The `ski.filters.threshold_otsu()` function can be used to determine
 the threshold automatically via Otsu's method.

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -356,7 +356,7 @@ if you are interested),
 but the outcome is that Otsu's method finds a threshold value between
 the two peaks of a grayscale histogram.
 Note there is a third peak very close to 1.0 which corresponds to the white label and disk on the 
-left hand side of the image. It would be a good idea to crop the image to remove these white pixels 
+left hand side of the image. It would be a good idea to remove these white pixels 
 before calculating the Otsu threshold. We will discuss how to do this later in the episode but for 
 now we will continue without removing them.
 

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -466,10 +466,10 @@ def measure_root_mass(filename, sigma=1.0):
     binary_mask = blurred_image > t
 
     # determine root mass ratio
-    rootPixels = np.count_nonzero(binary_mask)
+    root_pixels = np.count_nonzero(binary_mask)
     w = binary_mask.shape[1]
     h = binary_mask.shape[0]
-    density = rootPixels / (w * h)
+    density = root_pixels / (w * h)
 
     return density
 ```

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -357,7 +357,8 @@ but the outcome is that Otsu's method finds a threshold value between
 the two peaks of a grayscale histogram.
 Note there is a third peak very close to 1.0 which corresponds to the white label and disk on the 
 left hand side of the image. It would be a good idea to crop the image to remove these white pixels 
-before calculating the Otsu threshold but for now we will continue without doing this.
+before calculating the Otsu threshold. We will discuss how to do this later in the episode but for 
+now we will continue without removing them.
 
 The `ski.filters.threshold_otsu()` function can be used to determine
 the threshold automatically via Otsu's method.


### PR DESCRIPTION
Three suggestions:

1. The text interpreting the histogram of `data/maize-root-cluster.jpg` implies  that the peak at near 1.0 corresponds to the signal we are interested in (the root). This is actually the label and disk as covered later in the episode. Text altered and more detailed explanation added.
2. Variable names with underscores to be consistent.
3. In the solution to "IGNORING MORE OF THE IMAGES – IMPLEMENTATION (30 MIN - OPTIONAL, NOT INCLUDED IN TIMING)" the bright pixels (>0.95) are set to zero before calculating the Otsu threshold. I think it is best practice to just exclude them when calculating the threshold as the additional zero pixels will slightly distort the histogram. Solution altered to use this approach.