### PR TITLE
Episodes modified using Matplotlib Object Oriented Style

### DIFF
--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -290,7 +290,6 @@ zero = iio.imread(uri="data/eight.tif")
 zero[2,1]= 1.0
 
 # The following line of code creates a new figure for imshow to use in displaying our output.
-# Without it, the image would overwrite our previous image in the cell above
 fig, ax = plt.subplots()
 ax.imshow(zero)
 print(zero)

--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -228,7 +228,8 @@ With that taken care of, let us display the image we have loaded, using
 the `imshow` function from the `matplotlib.pyplot` module.
 
 ```python
-plt.imshow(eight)
+fig, ax = plt.subplots()
+ax.imshow(eight)
 ```
 
 ![](fig/eight.png){alt='Image of 8'}
@@ -289,9 +290,9 @@ zero = iio.imread(uri="data/eight.tif")
 zero[2,1]= 1.0
 
 # The following line of code creates a new figure for imshow to use in displaying our output.
-# Without it, plt.imshow() would overwrite our previous image in the cell above
+# Without it, the image would overwrite our previous image in the cell above
 fig, ax = plt.subplots()
-plt.imshow(zero)
+ax.imshow(zero)
 print(zero)
 ```
 
@@ -365,7 +366,7 @@ five = iio.imread(uri="data/eight.tif")
 five[1,2]= 1.0
 five[3,0]= 1.0
 fig, ax = plt.subplots()
-plt.imshow(five)
+ax.imshow(five)
 print(five)
 ```
 
@@ -402,7 +403,7 @@ three_colours = three_colours * 128
 # so you end up with the values 0., 128., and 255.
 three_colours[2,:] = 255.
 fig, ax = plt.subplots()
-plt.imshow(three_colours)
+ax.imshow(three_colours)
 print(three_colours)
 ```
 
@@ -436,7 +437,7 @@ a mapped continuum of intensities: greyscale.
 
 ```python
 fig, ax = plt.subplots()
-plt.imshow(three_colours,cmap=plt.cm.gray)
+ax.imshow(three_colours,cmap=plt.cm.gray)
 ```
 
 ![](fig/grayscale.png){alt='Image in greyscale'}
@@ -472,7 +473,7 @@ pseudorandomizer = np.random.RandomState(2021)
 checkerboard = pseudorandomizer.randint(0, 255, size=(4, 4, 3))
 # restore the default map as you show the image
 fig, ax = plt.subplots()
-plt.imshow(checkerboard)
+ax.imshow(checkerboard)
 # display the arrays
 print(checkerboard)
 ```
@@ -535,7 +536,7 @@ a 1d matrix that has a one for the channel we want to keep and zeros for the res
 ```python
 red_channel = checkerboard * [1, 0, 0]
 fig, ax = plt.subplots()
-plt.imshow(red_channel)
+ax.imshow(red_channel)
 ```
 
 ![](fig/checkerboard-red-channel.png){alt='Image of red channel'}
@@ -543,7 +544,7 @@ plt.imshow(red_channel)
 ```python
 green_channel = checkerboard * [0, 1, 0]
 fig, ax = plt.subplots()
-plt.imshow(green_channel)
+ax.imshow(green_channel)
 ```
 
 ![](fig/checkerboard-green-channel.png){alt='Image of green channel'}
@@ -551,7 +552,7 @@ plt.imshow(green_channel)
 ```python
 blue_channel = checkerboard * [0, 0, 1]
 fig, ax = plt.subplots()
-plt.imshow(blue_channel)
+ax.imshow(blue_channel)
 ```
 
 ![](fig/checkerboard-blue-channel.png){alt='Image of blue channel'}

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -65,7 +65,7 @@ ax.imshow(chair)
 
 Once we have the image in the program,
 we first call `plt.subplots()` so that we will have
-a fresh figure with a set of axis independent from our previous calls.
+a fresh figure with a set of axes independent from our previous calls.
 Next we call `ax.imshow()` in order to display the image.
 
 Now, we will save the image in another format:

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -64,7 +64,7 @@ ax.imshow(chair)
 ```
 
 Once we have the image in the program,
-we first call `plt.subplots()` so that we will have
+we first call `fig, ax = plt.subplots()` so that we will have
 a fresh figure with a set of axes independent from our previous calls.
 Next we call `ax.imshow()` in order to display the image.
 

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -60,13 +60,13 @@ Next, we will do something with the image:
 
 ```python
 fig, ax = plt.subplots()
-plt.imshow(chair)
+ax.imshow(chair)
 ```
 
 Once we have the image in the program,
 we first call `plt.subplots()` so that we will have
 a fresh figure with a set of axis independent from our previous calls.
-Next we call `plt.imshow()` in order to display the image.
+Next we call `ax.imshow()` in order to display the image.
 
 Now, we will save the image in another format:
 
@@ -181,7 +181,7 @@ If we don't convert it before saving,
 
 Next, write the resized image out to a new file named `resized.jpg`
 in your data directory.
-Finally, use `plt.imshow()` with each of your image variables to display
+Finally, use `ax.imshow()` with each of your image variables to display
 both images in your notebook.
 Don't forget to use `fig, ax = plt.subplots()` so you don't overwrite
 the first image with the second.
@@ -214,9 +214,9 @@ iio.imwrite(uri="data/resized_chair.jpg", image=resized_chair)
 
 # display images
 fig, ax = plt.subplots()
-plt.imshow(chair)
+ax.imshow(chair)
 fig, ax = plt.subplots()
-plt.imshow(resized_chair)
+ax.imshow(resized_chair)
 ```
 
 The script resizes the `data/chair.jpg` image by a factor of 10 in both dimensions,
@@ -271,7 +271,7 @@ maize_roots = np.array(maize_roots)
 
 # display original image
 fig, ax = plt.subplots()
-plt.imshow(maize_roots)
+ax.imshow(maize_roots)
 ```
 
 Now we can threshold the image and display the result.
@@ -282,7 +282,7 @@ maize_roots[maize_roots < 128] = 0
 
 # display modified image
 fig, ax = plt.subplots()
-plt.imshow(maize_roots)
+ax.imshow(maize_roots)
 ```
 
 The NumPy command to ignore all low-intensity pixels is `roots[roots < 128] = 0`.
@@ -331,12 +331,12 @@ chair = iio.imread(uri="data/chair.jpg")
 
 # display original image
 fig, ax = plt.subplots()
-plt.imshow(chair)
+ax.imshow(chair)
 
 # convert to grayscale and display
 gray_chair = ski.color.rgb2gray(chair)
 fig, ax = plt.subplots()
-plt.imshow(gray_chair, cmap="gray")
+ax.imshow(gray_chair, cmap="gray")
 ```
 
 We can also load colour images as grayscale directly by
@@ -350,7 +350,7 @@ gray_chair = iio.imread(uri="data/chair.jpg", mode="L")
 
 # display grayscale image
 fig, ax = plt.subplots()
-plt.imshow(gray_chair, cmap="gray")
+ax.imshow(gray_chair, cmap="gray")
 ```
 
 The first argument to `iio.imread()` is the filename of the image.
@@ -415,7 +415,6 @@ sudoku_gray_background[sudoku_gray_background > 192] = 192
 Finally, display the original and modified images side by side. Note that we have to specify `vmin=0` and `vmax=255` as the range of the colorscale because it would otherwise automatically adjust to the new range 0-192.
 
 ```python
-fig, ax = plt.subplots()
 fig, ax = plt.subplots(ncols=2)
 ax[0].imshow(sudoku, cmap="gray", vmin=0, vmax=255)
 ax[1].imshow(sudoku_gray_background, cmap="gray", vmin=0, vmax=255)
@@ -430,11 +429,11 @@ ax[1].imshow(sudoku_gray_background, cmap="gray", vmin=0, vmax=255)
 ## Plotting single channel images (cmap, vmin, vmax)
 
 Compared to a colour image, a grayscale image contains only a single
-intensity value per pixel. When we plot such an image with `plt.imshow`,
+intensity value per pixel. When we plot such an image with `ax.imshow`,
 Matplotlib uses a colour map, to assign each intensity value a colour.
 The default colour map is called "viridis" and maps low values to purple
 and high values to yellow. We can instruct Matplotlib to map low values
-to black and high values to white instead, by calling `plt.imshow` with
+to black and high values to white instead, by calling `ax.imshow` with
 `cmap="gray"`.
 [The documentation contains an overview of pre-defined colour maps](https://matplotlib.org/stable/gallery/color/colormap_reference.html).
 
@@ -499,7 +498,7 @@ A script to create the subimage would start by loading the image:
 board = iio.imread(uri="data/board.jpg")
 board = np.array(board)
 fig, ax = plt.subplots()
-plt.imshow(board)
+ax.imshow(board)
 ```
 
 Then we use array slicing to
@@ -509,7 +508,7 @@ create a new image with our selected area and then display the new image.
 # extract, display, and save sub-image
 clipped_board = board[60:151, 135:481, :]
 fig, ax = plt.subplots()
-plt.imshow(clipped_board)
+ax.imshow(clipped_board)
 iio.imwrite(uri="data/clipped_board.tif", image=clipped_board)
 ```
 
@@ -520,7 +519,7 @@ We can also change the values in an image, as shown next.
 color = board[330, 90]
 board[60:151, 135:481] = color
 fig, ax = plt.subplots()
-plt.imshow(board)
+ax.imshow(board)
 ```
 
 First, we sample a single pixel's colour at a particular location of the
@@ -559,12 +558,12 @@ in the image.
 # load and display original image
 maize_roots = iio.imread(uri="data/maize-root-cluster.jpg")
 fig, ax = plt.subplots()
-plt.imshow(maize_roots)
+ax.imshow(maize_roots)
 
 # extract and display sub-image
 clipped_maize = maize_roots[0:400, 275:550, :]
 fig, ax = plt.subplots()
-plt.imshow(clipped_maize)
+ax.imshow(clipped_maize)
 
 
 # save sub-image

--- a/episodes/04-drawing.md
+++ b/episodes/04-drawing.md
@@ -77,7 +77,7 @@ image:
 maize_seedlings = iio.imread(uri="data/maize-seedlings.tif")
 
 fig, ax = plt.subplots()
-plt.imshow(maize_seedlings)
+ax.imshow(maize_seedlings)
 ```
 
 We load and display the initial image in the same way we have done before.
@@ -117,7 +117,7 @@ mask[rr, cc] = False
 
 # Display mask image
 fig, ax = plt.subplots()
-plt.imshow(mask, cmap="gray")
+ax.imshow(mask, cmap="gray")
 ```
 
 Here is what our constructed mask looks like:
@@ -229,7 +229,7 @@ canvas[rr, cc] = (0, 255, 0)
 ```python
 # Display the image
 fig, ax = plt.subplots()
-plt.imshow(canvas)
+ax.imshow(canvas)
 ```
 
 We could expand this solution, if we wanted,
@@ -258,7 +258,7 @@ for i in range(15):
 
 # display the results
 fig, ax = plt.subplots()
-plt.imshow(canvas)
+ax.imshow(canvas)
 ```
 
 We could expand this even further to also
@@ -306,7 +306,7 @@ for i in range(15):
 
 # display the results
 fig, ax = plt.subplots()
-plt.imshow(canvas)
+ax.imshow(canvas)
 ```
 
 :::::::::::::::::::::::::
@@ -374,7 +374,7 @@ Then, we display the masked image.
 
 ```python
 fig, ax = plt.subplots()
-plt.imshow(maize_seedlings)
+ax.imshow(maize_seedlings)
 ```
 
 The resulting masked image should look like this:
@@ -423,7 +423,7 @@ remote[mask] = 0
 
 # Display the result
 fig, ax = plt.subplots()
-plt.imshow(remote)
+ax.imshow(remote)
 ```
 
 :::::::::::::::::::::::::
@@ -443,7 +443,7 @@ wellplate = np.array(wellplate)
 
 # Display the image
 fig, ax = plt.subplots()
-plt.imshow(wellplate)
+ax.imshow(wellplate)
 ```
 
 ![](data/wellplate-01.jpg){alt='96-well plate'}
@@ -491,7 +491,7 @@ wellplate[mask] = 0
 
 # display the result
 fig, ax = plt.subplots()
-plt.imshow(wellplate)
+ax.imshow(wellplate)
 ```
 
 :::::::::::::::::::::::::
@@ -564,7 +564,7 @@ wellplate[mask] = 0
 
 # display the result
 fig, ax = plt.subplots()
-plt.imshow(wellplate)
+ax.imshow(wellplate)
 ```
 
 :::::::::::::::::::::::::

--- a/episodes/05-creating-histograms.md
+++ b/episodes/05-creating-histograms.md
@@ -450,6 +450,6 @@ ax.set_ylabel("pixel count")
 - In many cases, we can load images in grayscale by passing the `mode="L"` argument to the `iio.imread()` function.
 - We can create histograms of images with the `np.histogram` function.
 - We can separate the RGB channels of an image using slicing operations.
-- We can display histograms using the `matplotlib pyplot` `subplots()`, `set_title()`, `set_xlabel()`, `set_ylabel()`, `set_xlim()`, `plot()`, and `show()` functions.
+- We can display histograms using `ax.plot()` with the `bin_edges` and `histogram` values returned by `np.histogram()`.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/05-creating-histograms.md
+++ b/episodes/05-creating-histograms.md
@@ -451,6 +451,6 @@ ax.set_ylabel("pixel count")
 - We can create histograms of images with the `np.histogram` function.
 - We can display histograms using `ax.plot()` with the `bin_edges` and `histogram` values returned by `np.histogram()`.
 - The plot can be customised using `set_xlabel()`, `set_ylabel()`, `set_xlim()`, `set_ylim()`, and `set_title()`.
-- We can separate the RGB channels of an image using slicing operations.
+- We can separate the colour channels of an RGB image using slicing operations and create histograms for each colour channel separately.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/05-creating-histograms.md
+++ b/episodes/05-creating-histograms.md
@@ -65,7 +65,7 @@ plant_seedling = ski.util.img_as_float(plant_seedling)
 
 # display the image
 fig, ax = plt.subplots()
-plt.imshow(plant_seedling, cmap="gray")
+ax.imshow(plant_seedling, cmap="gray")
 ```
 
 ![](fig/plant-seedling-grayscale.png){alt='Plant seedling'}
@@ -112,28 +112,28 @@ by taking advantage of the plotting facilities of the Matplotlib library.
 
 ```python
 # configure and draw the histogram figure
-plt.figure()
-plt.title("Grayscale Histogram")
-plt.xlabel("grayscale value")
-plt.ylabel("pixel count")
-plt.xlim([0.0, 1.0])  # <- named arguments do not work here
+fig, ax = plt.subplots()
+ax.set_title("Grayscale Histogram")
+ax.set_xlabel("grayscale value")
+ax.set_ylabel("pixel count")
+ax.set_xlim([0.0, 1.0])  # <- named arguments do not work here
 
-plt.plot(bin_edges[0:-1], histogram)  # <- or here
+ax.plot(bin_edges[0:-1], histogram)  # <- or here
 ```
 
-We create the plot with `plt.figure()`,
-then label the figure and the coordinate axes with `plt.title()`,
-`plt.xlabel()`, and `plt.ylabel()` functions.
+We create the plot with `plt.subplots()`,
+then label the figure and the coordinate axes with `ax.set_title()`,
+`ax.set_xlabel()`, and `ax.set_ylabel()` functions.
 The last step in the preparation of the figure is to
 set the limits on the values on the x-axis with
-the `plt.xlim([0.0, 1.0])` function call.
+the `ax.set_xlim([0.0, 1.0])` function call.
 
 :::::::::::::::::::::::::::::::::::::::::  callout
 
 ## Variable-length argument lists
 
 Note that we cannot used named parameters for the
-`plt.xlim()` or `plt.plot()` functions.
+`ax.set_xlim()` or `ax.plot()` functions.
 This is because these functions are defined to take an arbitrary number of
 *unnamed* arguments.
 The designers wrote the functions this way because they are very versatile,
@@ -144,7 +144,7 @@ would be complicated.
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Finally, we create the histogram plot itself with
-`plt.plot(bin_edges[0:-1], histogram)`.
+`ax.plot(bin_edges[0:-1], histogram)`.
 We use the **left** bin edges as x-positions for the histogram values by
 indexing the `bin_edges` array to ignore the last value
 (the **right** edge of the last bin).
@@ -158,15 +158,15 @@ it produces this histogram:
 ## Histograms in Matplotlib
 
 Matplotlib provides a dedicated function to compute and display histograms:
-`plt.hist()`.
+`ax.hist()`.
 We will not use it in this lesson in order to understand how to
 calculate histograms in more detail.
 In practice, it is a good idea to use this function,
-because it visualises histograms more appropriately than `plt.plot()`.
+because it visualises histograms more appropriately than `ax.plot()`.
 Here, you could use it by calling
-`plt.hist(image.flatten(), bins=256, range=(0, 1))`
+`ax.hist(image.flatten(), bins=256, range=(0, 1))`
 instead of
-`np.histogram()` and `plt.plot()`
+`np.histogram()` and `ax.plot()`
 (`*.flatten()` is a NumPy function that converts our two-dimensional
 image into a one-dimensional array).
 
@@ -206,7 +206,7 @@ plant_seedling = ski.util.img_as_float(plant_seedling)
 
 # display the image
 fig, ax = plt.subplots()
-plt.imshow(plant_seedling, cmap="gray")
+ax.imshow(plant_seedling, cmap="gray")
 
 # create mask here, using np.zeros() and ski.draw.rectangle()
 mask = np.zeros(shape=plant_seedling.shape, dtype="bool")
@@ -215,19 +215,19 @@ mask[rr, cc] = True
 
 # display the mask
 fig, ax = plt.subplots()
-plt.imshow(mask, cmap="gray")
+ax.imshow(mask, cmap="gray")
 
 # mask the image and create the new histogram
 histogram, bin_edges = np.histogram(plant_seedling[mask], bins=256, range=(0.0, 1.0))
 
 # configure and draw the histogram figure
-plt.figure()
+fig, ax = plt.subplots()
 
-plt.title("Grayscale Histogram")
-plt.xlabel("grayscale value")
-plt.ylabel("pixel count")
-plt.xlim([0.0, 1.0])
-plt.plot(bin_edges[0:-1], histogram)
+ax.set_title("Grayscale Histogram")
+ax.set_xlabel("grayscale value")
+ax.set_ylabel("pixel count")
+ax.set_xlim([0.0, 1.0])
+ax.plot(bin_edges[0:-1], histogram)
 
 ```
 
@@ -254,7 +254,7 @@ plant_seedling = iio.imread(uri="data/plant-seedling.jpg")
 
 # display the image
 fig, ax = plt.subplots()
-plt.imshow(plant_seedling)
+ax.imshow(plant_seedling)
 ```
 
 We read the original image, now in full colour, and display it.
@@ -271,17 +271,17 @@ colors = ("red", "green", "blue")
 
 # create the histogram plot, with three lines, one for
 # each color
-plt.figure()
-plt.xlim([0, 256])
+fig, ax = plt.subplots()
+ax.set_xlim([0, 256])
 for channel_id, color in enumerate(colors):
     histogram, bin_edges = np.histogram(
         plant_seedling[:, :, channel_id], bins=256, range=(0, 256)
     )
-    plt.plot(bin_edges[0:-1], histogram, color=color)
+    ax.plot(bin_edges[0:-1], histogram, color=color)
 
-plt.title("Color Histogram")
-plt.xlabel("Color value")
-plt.ylabel("Pixel count")
+ax.set_title("Color Histogram")
+ax.set_xlabel("Color value")
+ax.set_ylabel("Pixel count")
 ```
 
 We will draw the histogram line for each channel in a different colour,
@@ -290,7 +290,7 @@ and so we create a tuple of the colours to use for the three lines with the
 `colors = ("red", "green", "blue")`
 
 line of code.
-Then, we limit the range of the x-axis with the `plt.xlim()` function call.
+Then, we limit the range of the x-axis with the `ax.set_xlim()` function call.
 
 Next, we use the `for` control structure to iterate through the three channels,
 plotting an appropriately-coloured histogram line for each.
@@ -351,7 +351,7 @@ with the
 function call,
 and then add a histogram line of the correct colour to the plot with the
 
-`plt.plot(bin_edges[0:-1], histogram, color=color)`
+`ax.plot(bin_edges[0:-1], histogram, color=color)`
 
 function call.
 Note the use of our loop variables, `channel_id` and `color`.
@@ -376,7 +376,7 @@ wellplate = iio.imread(uri="data/wellplate-02.tif")
 
 # display the image
 fig, ax = plt.subplots()
-plt.imshow(wellplate)
+ax.imshow(wellplate)
 ```
 
 ![](fig/wellplate-02.jpg){alt='Well plate image'}
@@ -418,15 +418,15 @@ masked_img[~mask] = 0
 # create a new figure and display masked_img, to verify the
 # validity of your mask
 fig, ax = plt.subplots()
-plt.imshow(masked_img)
+ax.imshow(masked_img)
 
 # list to select colors of each channel line
 colors = ("red", "green", "blue")
 
 # create the histogram plot, with three lines, one for
 # each color
-plt.figure()
-plt.xlim([0, 256])
+fig, ax = plt.subplots()
+ax.set_xlim([0, 256])
 for (channel_id, color) in enumerate(colors):
     # use your circular mask to apply the histogram
     # operation to the 7th well of the first row
@@ -434,10 +434,10 @@ for (channel_id, color) in enumerate(colors):
         wellplate[:, :, channel_id][mask], bins=256, range=(0, 256)
     )
 
-    plt.plot(histogram, color=color)
+    ax.plot(histogram, color=color)
 
-plt.xlabel("color value")
-plt.ylabel("pixel count")
+ax.set_xlabel("color value")
+ax.set_ylabel("pixel count")
 
 ```
 
@@ -450,6 +450,6 @@ plt.ylabel("pixel count")
 - In many cases, we can load images in grayscale by passing the `mode="L"` argument to the `iio.imread()` function.
 - We can create histograms of images with the `np.histogram` function.
 - We can separate the RGB channels of an image using slicing operations.
-- We can display histograms using the `matplotlib pyplot` `figure()`, `title()`, `xlabel()`, `ylabel()`, `xlim()`, `plot()`, and `show()` functions.
+- We can display histograms using the `matplotlib pyplot` `subplots()`, `set_title()`, `set_xlabel()`, `set_ylabel()`, `set_xlim()`, `plot()`, and `show()` functions.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/05-creating-histograms.md
+++ b/episodes/05-creating-histograms.md
@@ -449,7 +449,8 @@ ax.set_ylabel("pixel count")
 
 - In many cases, we can load images in grayscale by passing the `mode="L"` argument to the `iio.imread()` function.
 - We can create histograms of images with the `np.histogram` function.
-- We can separate the RGB channels of an image using slicing operations.
 - We can display histograms using `ax.plot()` with the `bin_edges` and `histogram` values returned by `np.histogram()`.
+- The plot can be customised using `set_xlabel()`, `set_ylabel()`, `set_xlim()`, `set_ylim()`, and `set_title()`.
+- We can separate the RGB channels of an image using slicing operations.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/06-blurring.md
+++ b/episodes/06-blurring.md
@@ -274,7 +274,7 @@ image = iio.imread(uri="data/gaussian-original.png")
 
 # display the image
 fig, ax = plt.subplots()
-plt.imshow(image)
+ax.imshow(image)
 ```
 
 ![](data/gaussian-original.png){alt='Original image'}
@@ -324,7 +324,7 @@ Finally, we display the blurred image:
 ```python
 # display blurred image
 fig, ax = plt.subplots()
-plt.imshow(blurred)
+ax.imshow(blurred)
 ```
 
 ![](fig/gaussian-blurred.png){alt='Blurred image'}
@@ -378,9 +378,7 @@ image_gray_pixels_slice = image_gray[Y, :]
 # guarantee the intensity values are in the [0:255] range (unsigned integers)
 image_gray_pixels_slice = ski.img_as_ubyte(image_gray_pixels_slice)
 
-fig = plt.figure()
-ax = fig.add_subplot()
-
+fig, ax = plt.subplots()
 ax.plot(image_gray_pixels_slice, color='red')
 ax.set_ylim(255, 0)
 ax.set_ylabel('L')
@@ -403,9 +401,7 @@ image_blur = ski.filters.gaussian(image_gray, sigma=3)
 image_blur_pixels_slice = image_blur[Y, :]
 image_blur_pixels_slice = ski.img_as_ubyte(image_blur_pixels_slice)
 
-fig = plt.figure()
-ax = fig.add_subplot()
-
+fig, ax = plt.subplots()
 ax.plot(image_blur_pixels_slice, 'red')
 ax.set_ylim(255, 0)
 ax.set_ylabel('L')
@@ -506,7 +502,7 @@ blurred = ski.filters.gaussian(
 
 # display blurred image
 fig, ax = plt.subplots()
-plt.imshow(blurred)
+ax.imshow(blurred)
 ```
 
 ![](fig/rectangle-gaussian-blurred.png){alt='Rectangular kernel blurred image'}

--- a/episodes/07-thresholding.md
+++ b/episodes/07-thresholding.md
@@ -65,7 +65,7 @@ crudely cut shapes set against a white background.
 shapes01 = iio.imread(uri="data/shapes-01.jpg")
 
 fig, ax = plt.subplots()
-plt.imshow(shapes01)
+ax.imshow(shapes01)
 ```
 
 ![](data/shapes-01.jpg){alt='Image with geometric shapes on white background' .image-with-shadow}
@@ -92,7 +92,7 @@ gray_shapes = ski.color.rgb2gray(shapes01)
 blurred_shapes = ski.filters.gaussian(gray_shapes, sigma=1.0)
 
 fig, ax = plt.subplots()
-plt.imshow(blurred_shapes, cmap="gray")
+ax.imshow(blurred_shapes, cmap="gray")
 ```
 
 ![](fig/shapes-01-grayscale.png){alt='Grayscale image of the geometric shapes' .image-with-shadow}
@@ -118,11 +118,11 @@ The histogram for the shapes image shown above can be produced as in
 histogram, bin_edges = np.histogram(blurred_shapes, bins=256, range=(0.0, 1.0))
 
 fig, ax = plt.subplots()
-plt.plot(bin_edges[0:-1], histogram)
-plt.title("Grayscale Histogram")
-plt.xlabel("grayscale value")
-plt.ylabel("pixels")
-plt.xlim(0, 1.0)
+ax.plot(bin_edges[0:-1], histogram)
+ax.set_title("Grayscale Histogram")
+ax.set_xlabel("grayscale value")
+ax.set_ylabel("pixels")
+ax.set_xlim(0, 1.0)
 ```
 
 ![](fig/shapes-01-histogram.png){alt='Grayscale histogram of the geometric shapes image'}
@@ -144,7 +144,7 @@ Here, we want to turn "on" all pixels which have values smaller than the thresho
 so we use the less operator `<` to compare the `blurred_image` to the threshold `t`.
 The operator returns a mask, that we capture in the variable `binary_mask`.
 It has only one channel, and each of its values is either 0 or 1.
-The binary mask created by the thresholding operation can be shown with `plt.imshow`,
+The binary mask created by the thresholding operation can be shown with `ax.imshow`,
 where the `False` entries are shown as black pixels
 (0-valued) and the `True` entries are shown as white pixels
 (1-valued).
@@ -155,7 +155,7 @@ t = 0.8
 binary_mask = blurred_shapes < t
 
 fig, ax = plt.subplots()
-plt.imshow(binary_mask, cmap="gray")
+ax.imshow(binary_mask, cmap="gray")
 ```
 
 ![](fig/shapes-01-mask.png){alt='Binary mask of the geometric shapes created by thresholding'}
@@ -202,7 +202,7 @@ selection = shapes01.copy()
 selection[~binary_mask] = 0
 
 fig, ax = plt.subplots()
-plt.imshow(selection)
+ax.imshow(selection)
 ```
 
 ![](fig/shapes-01-selected.png){alt='Selected shapes after applying binary mask'}
@@ -233,11 +233,11 @@ gray_shapes = ski.color.rgb2gray(shapes)
 histogram, bin_edges = np.histogram(gray_shapes, bins=256, range=(0.0, 1.0))
 
 fig, ax = plt.subplots()
-plt.plot(bin_edges[0:-1], histogram)
-plt.title("Graylevel histogram")
-plt.xlabel("gray value")
-plt.ylabel("pixel count")
-plt.xlim(0, 1.0)
+ax.plot(bin_edges[0:-1], histogram)
+ax.set_title("Graylevel histogram")
+ax.set_xlabel("gray value")
+ax.set_ylabel("pixel count")
+ax.set_xlim(0, 1.0)
 ```
 
 ![](fig/shapes-02-histogram.png){alt='Grayscale histogram of the second geometric shapes image'}
@@ -270,7 +270,7 @@ t = 0.5
 binary_mask = gray_shapes > t
 
 fig, ax = plt.subplots()
-plt.imshow(binary_mask, cmap="gray")
+ax.imshow(binary_mask, cmap="gray")
 ```
 
 ![](fig/shapes-02-mask.png){alt='Binary mask created by thresholding the second geometric shapes image'}
@@ -283,7 +283,7 @@ selection = shapes02.copy()
 selection[~binary_mask] = 0
 
 fig, ax = plt.subplots()
-plt.imshow(selection)
+ax.imshow(selection)
 ```
 
 ![](fig/shapes-02-selected.png){alt='Selected shapes after applying binary mask to the second geometric shapes image'}
@@ -321,7 +321,7 @@ we have seen before in
 maize_roots = iio.imread(uri="data/maize-root-cluster.jpg")
 
 fig, ax = plt.subplots()
-plt.imshow(maize_roots)
+ax.imshow(maize_roots)
 ```
 
 ![](data/maize-root-cluster.jpg){alt='Image of a maize root'}
@@ -339,11 +339,11 @@ blurred_image = ski.filters.gaussian(gray_image, sigma=1.0)
 # show the histogram of the blurred image
 histogram, bin_edges = np.histogram(blurred_image, bins=256, range=(0.0, 1.0))
 fig, ax = plt.subplots()
-plt.plot(bin_edges[0:-1], histogram)
-plt.title("Graylevel histogram")
-plt.xlabel("gray value")
-plt.ylabel("pixel count")
-plt.xlim(0, 1.0)
+ax.plot(bin_edges[0:-1], histogram)
+ax.set_title("Graylevel histogram")
+ax.set_xlabel("gray value")
+ax.set_ylabel("pixel count")
+ax.set_xlim(0, 1.0)
 ```
 
 ![](fig/maize-root-cluster-histogram.png){alt='Grayscale histogram of the maize root image'}
@@ -397,7 +397,7 @@ those below the threshold will be turned off.
 binary_mask = blurred_image > t
 
 fig, ax = plt.subplots()
-plt.imshow(binary_mask, cmap="gray")
+ax.imshow(binary_mask, cmap="gray")
 ```
 
 ![](fig/maize-root-cluster-mask.png){alt='Binary mask of the maize root system'}
@@ -410,7 +410,7 @@ selection = maize_roots.copy()
 selection[~binary_mask] = 0
 
 fig, ax = plt.subplots()
-plt.imshow(selection)
+ax.imshow(selection)
 ```
 
 ![](fig/maize-root-cluster-selected.png){alt='Masked selection of the maize root system'}
@@ -730,11 +730,11 @@ gray_image = ski.color.rgb2gray(bacteria)
 blurred_image = ski.filters.gaussian(gray_image, sigma=1.0)
 histogram, bin_edges = np.histogram(blurred_image, bins=256, range=(0.0, 1.0))
 fig, ax = plt.subplots()
-plt.plot(bin_edges[0:-1], histogram)
-plt.title("Graylevel histogram")
-plt.xlabel("gray value")
-plt.ylabel("pixel count")
-plt.xlim(0, 1.0)
+ax.plot(bin_edges[0:-1], histogram)
+ax.set_title("Graylevel histogram")
+ax.set_xlabel("gray value")
+ax.set_ylabel("pixel count")
+ax.set_xlim(0, 1.0)
 ```
 
 ![](fig/colonies-01-histogram.png){alt='Grayscale histogram of the bacteria colonies image'}
@@ -753,7 +753,7 @@ t = 0.2
 binary_mask = blurred_image < t
 
 fig, ax = plt.subplots()
-plt.imshow(binary_mask, cmap="gray")
+ax.imshow(binary_mask, cmap="gray")
 ```
 
 ![](fig/colonies-01-mask.png){alt='Binary mask of the bacteria colonies image'}

--- a/episodes/08-connected-components.md
+++ b/episodes/08-connected-components.md
@@ -315,8 +315,8 @@ display the labeled image like so:
 labeled_image, count = connected_components(filename="data/shapes-01.jpg", sigma=2.0, t=0.9, connectivity=2)
 
 fig, ax = plt.subplots()
-plt.imshow(labeled_image)
-plt.axis("off");
+ax.imshow(labeled_image)
+ax.set_axis_off();
 ```
 
 ::::::::::::::::  spoiler
@@ -362,7 +362,7 @@ is to explicitly specify the data range we want the colormap to cover:
 
 ```python
 fig, ax = plt.subplots()
-plt.imshow(labeled_image, vmin=np.min(labeled_image), vmax=np.max(labeled_image))
+ax.imshow(labeled_image, vmin=np.min(labeled_image), vmax=np.max(labeled_image))
 ```
 
 Note this is the default behaviour for newer versions of `matplotlib.pyplot.imshow`. 
@@ -375,7 +375,7 @@ Alternatively we could convert the image to RGB and then display it.
 
 ## Suppressing outputs in Jupyter Notebooks
 
-We just used `plt.axis("off");` to hide the axis from the image for a visually cleaner figure. The
+We just used `ax.set_axis_off();` to hide the axis from the image for a visually cleaner figure. The
 semicolon is added to supress the output(s) of the statement, in this [case](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.axis.html) 
 the axis limits. This is specific to Jupyter Notebooks.
 
@@ -394,8 +394,8 @@ We can use the following commands to convert and show the image:
 colored_label_image = ski.color.label2rgb(labeled_image, bg_label=0)
 
 fig, ax = plt.subplots()
-plt.imshow(colored_label_image)
-plt.axis("off");
+ax.imshow(colored_label_image)
+ax.set_axis_off();
 ```
 
 ![](fig/shapes-01-labeled.png){alt='Labeled objects'}
@@ -539,9 +539,9 @@ The histogram can be plotted with
 
 ```python
 fig, ax = plt.subplots()
-plt.hist(object_areas)
-plt.xlabel("Area (pixels)")
-plt.ylabel("Number of objects");
+ax.hist(object_areas)
+ax.set_xlabel("Area (pixels)")
+ax.set_ylabel("Number of objects");
 ```
 
 ![](fig/shapes-01-areas-histogram.png){alt='Histogram of object areas'}
@@ -742,8 +742,8 @@ labeled_image, count = enhanced_connected_components(filename="data/shapes-01.jp
 colored_label_image = ski.color.label2rgb(labeled_image, bg_label=0)
 
 fig, ax = plt.subplots()
-plt.imshow(colored_label_image)
-plt.axis("off");
+ax.imshow(colored_label_image)
+ax.set_axis_off();
 
 print("Found", count, "objects in the image.")
 ```
@@ -793,10 +793,10 @@ object_areas = np.insert(0, obj=1, values=object_areas)
 colored_area_image = object_areas[labeled_image]
 
 fig, ax = plt.subplots()
-im = plt.imshow(colored_area_image)
+im = ax.imshow(colored_area_image)
 cbar = fig.colorbar(im, ax=ax, shrink=0.85)
 cbar.ax.set_title("Area")
-plt.axis("off");
+ax.set_axis_off();
 ```
 
 ![](fig/shapes-01-objects-coloured-by-area.png){alt='Objects colored by area'}

--- a/episodes/09-challenges.md
+++ b/episodes/09-challenges.md
@@ -75,7 +75,7 @@ bacteria_image = iio.imread(uri="data/colonies-01.tif")
 
 # display the image
 fig, ax = plt.subplots()
-plt.imshow(bacteria_image)
+ax.imshow(bacteria_image)
 ```
 
 ![](fig/colonies-01.jpg){alt='Colony image 1'}
@@ -89,7 +89,7 @@ gray_bacteria = ski.color.rgb2gray(bacteria_image)
 
 # display the gray image
 fig, ax = plt.subplots()
-plt.imshow(gray_bacteria, cmap="gray")
+ax.imshow(gray_bacteria, cmap="gray")
 ```
 
 ![](fig/colonies-01-gray.png){alt='Gray Colonies'}
@@ -100,11 +100,11 @@ Next, we blur the image and create a histogram:
 blurred_image = ski.filters.gaussian(gray_bacteria, sigma=1.0)
 histogram, bin_edges = np.histogram(blurred_image, bins=256, range=(0.0, 1.0))
 fig, ax = plt.subplots()
-plt.plot(bin_edges[0:-1], histogram)
-plt.title("Graylevel histogram")
-plt.xlabel("gray value")
-plt.ylabel("pixel count")
-plt.xlim(0, 1.0)
+ax.plot(bin_edges[0:-1], histogram)
+ax.set_title("Graylevel histogram")
+ax.set_xlabel("gray value")
+ax.set_ylabel("pixel count")
+ax.set_xlim(0, 1.0)
 ```
 
 ![](fig/colonies-01-histogram.png){alt='Histogram image'}
@@ -118,7 +118,7 @@ Therefore, we choose a threshold that selects the small left peak:
 ```python
 mask = blurred_image < 0.2
 fig, ax = plt.subplots()
-plt.imshow(mask, cmap="gray")
+ax.imshow(mask, cmap="gray")
 ```
 
 ![](fig/colonies-01-mask.png){alt='Colony mask image'}
@@ -144,7 +144,7 @@ summary_image[mask] = colored_label_image[mask]
 
 # plot overlay
 fig, ax = plt.subplots()
-plt.imshow(summary_image)
+ax.imshow(summary_image)
 ```
 
 ![](fig/colonies-01-summary.png){alt='Sample morphometric output'}
@@ -166,7 +166,7 @@ def count_colonies(image_filename):
     summary_image = ski.color.gray2rgb(gray_bacteria)
     summary_image[mask] = colored_label_image[mask]
     fig, ax = plt.subplots()
-    plt.imshow(summary_image)
+    ax.imshow(summary_image)
 ```
 
 Now we can do this analysis on all the images via a for loop:
@@ -233,7 +233,7 @@ def count_colonies_enhanced(image_filename, sigma=1.0, min_colony_size=10, conne
     summary_image = ski.color.gray2rgb(gray_bacteria)
     summary_image[mask] = colored_label_image[mask]
     fig, ax = plt.subplots()
-    plt.imshow(summary_image)
+    ax.imshow(summary_image)
 ```
 
 :::::::::::::::::::::::::


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._
Closes #319 [Matplotlib is currently used in a hybrid way (explicit vs. implicit interfaces)]

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._
The episodes are now using Matplotlib Object Oriented Style. In a few places, I needed also to change the explanatory text when the text referred to displaying figures with Matplotlib.
In Episode 3, I simplified the two lines of code
fig, ax = plt.subplots()
fig, ax = plt.subplots(ncols=2)
removing the first line.


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
