### PR TITLE
Prefix functions used for customising plots.

### DIFF
--- a/episodes/05-creating-histograms.md
+++ b/episodes/05-creating-histograms.md
@@ -450,7 +450,7 @@ ax.set_ylabel("pixel count")
 - In many cases, we can load images in grayscale by passing the `mode="L"` argument to the `iio.imread()` function.
 - We can create histograms of images with the `np.histogram` function.
 - We can display histograms using `ax.plot()` with the `bin_edges` and `histogram` values returned by `np.histogram()`.
-- The plot can be customised using `set_xlabel()`, `set_ylabel()`, `set_xlim()`, `set_ylim()`, and `set_title()`.
+- The plot can be customised using `ax.set_xlabel()`, `ax.set_ylabel()`, `ax.set_xlim()`, `ax.set_ylim()`, and `ax.set_title()`.
 - We can separate the colour channels of an RGB image using slicing operations and create histograms for each colour channel separately.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
I just saw the last-minute edits in #321 and thought it would be more consistent to prefix these functions with `ax.`, as done line 126 and overall.


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
