### PR TITLE
Simpler solution for wellplate exercise

### DIFF
--- a/episodes/02-image-basics.md
+++ b/episodes/02-image-basics.md
@@ -287,7 +287,7 @@ Using array slicing, we can then address and assign a new value to that position
 
 ```python
 zero = iio.imread(uri="data/eight.tif")
-zero[2,1]= 1.0
+zero[2, 1]= 1.0
 
 # The following line of code creates a new figure for imshow to use in displaying our output.
 fig, ax = plt.subplots()
@@ -362,8 +362,8 @@ There are many possible solutions, but one method would be . . .
 
 ```python
 five = iio.imread(uri="data/eight.tif")
-five[1,2]= 1.0
-five[3,0]= 1.0
+five[1, 2] = 1.0
+five[3, 0] = 1.0
 fig, ax = plt.subplots()
 ax.imshow(five)
 print(five)
@@ -400,7 +400,7 @@ three_colours = three_colours * 128
 
 # set the middle row (index 2) to the value of 255.,
 # so you end up with the values 0., 128., and 255.
-three_colours[2,:] = 255.
+three_colours[2, :] = 255.
 fig, ax = plt.subplots()
 ax.imshow(three_colours)
 print(three_colours)
@@ -436,7 +436,7 @@ a mapped continuum of intensities: greyscale.
 
 ```python
 fig, ax = plt.subplots()
-ax.imshow(three_colours,cmap=plt.cm.gray)
+ax.imshow(three_colours, cmap="gray")
 ```
 
 ![](fig/grayscale.png){alt='Image in greyscale'}

--- a/episodes/03-skimage-images.md
+++ b/episodes/03-skimage-images.md
@@ -31,6 +31,8 @@ import ipympl
 import matplotlib.pyplot as plt
 import numpy as np
 import skimage as ski
+
+%matplotlib widget
 ```
 
 ## Reading, displaying, and saving images

--- a/episodes/04-drawing.md
+++ b/episodes/04-drawing.md
@@ -462,11 +462,21 @@ Your program should produce output that looks like this:
 
 ![](fig/wellplate-01-masked.jpg){alt='Masked 96-well plate'}
 
+*Hint: You can load `data/centers.txt` using*:
+
+```Python
+# load the well coordinates as a NumPy array
+centers = np.loadtxt("data/centers.txt", delimiter=" ")
+```
+
 :::::::::::::::  solution
 
 ## Solution
 
 ```python
+# load the well coordinates as a NumPy array
+centers = np.loadtxt("data/centers.txt", delimiter=" ")
+
 # read in original image
 wellplate = iio.imread(uri="data/wellplate-01.jpg")
 wellplate = np.array(wellplate)
@@ -474,17 +484,11 @@ wellplate = np.array(wellplate)
 # create the mask image
 mask = np.ones(shape=wellplate.shape[0:2], dtype="bool")
 
-# open and iterate through the centers file...
-with open("data/centers.txt", "r") as center_file:
-    for line in center_file:
-        # ... getting the coordinates of each well...
-        coordinates = line.split()
-        cx = int(coordinates[0])
-        ry = int(coordinates[1])
-
-        # ... and drawing a circle on the mask
-        rr, cc = ski.draw.disk(center=(ry, cx), radius=16, shape=wellplate.shape[0:2])
-        mask[rr, cc] = False
+# iterate through the well coordinates
+for cx, ry in centers:
+    # draw a circle on the mask at the well center
+    rr, cc = ski.draw.disk(center=(ry, cx), radius=16, shape=wellplate.shape[:2])
+    mask[rr, cc] = False
 
 # apply the mask
 wellplate[mask] = 0


### PR DESCRIPTION
This PR contains a couple minor suggestions and a simpler solution to the [wellplate exercise](https://bear-rsg.github.io/image-processing/04-drawing.html#masking-a-96-well-plate-image-30-min) which uses `np.loadtxt()` to load the .txt file containing the well coordinates. In my experience this has been much easier for learners to understand. Let me know what you think :)