### PR TITLE
Update setup instructions

### DIFF
--- a/episodes/files/environment.yml
+++ b/episodes/files/environment.yml
@@ -6,6 +6,6 @@ dependencies:
   - jupyterlab
   - numpy
   - matplotlib
-  - pandas
   - scikit-image
   - ipympl
+  - imageio

--- a/episodes/files/environment.yml
+++ b/episodes/files/environment.yml
@@ -1,0 +1,11 @@
+name: dc-image
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.11
+  - jupyterlab
+  - numpy
+  - matplotlib
+  - pandas
+  - scikit-image
+  - ipympl

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -21,7 +21,7 @@ e.g. your Desktop or a folder you have created for using in this workshop.
    If you already have a Python 3 setup that you are happy with, you can continue to use that (we recommend that you make sure your Python version is current).
    The next step assumes that `conda` is available to manage your Python environment.
 2. Setup an environment to work in during the lesson.
-   In a terminal or the MiniForge Prompt application, navigate to the location where you saved the unzipped data for the lesson and run the following command:
+   In a terminal (Linux/Mac) or the MiniForge Prompt application (Windows), navigate to the location where you saved the unzipped data for the lesson and run the following command:
 
    ```bash
    conda env create -f environment.yml
@@ -77,7 +77,7 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 
    Launch the MiniForge Prompt program and type `jupyter lab`.
    (Running this command on the standard Command Prompt will return an error:
-   `'conda' is not recognized as an internal or external command, operable program or batch file.`)
+   `'jupyter' is not recognized as an internal or external command, operable program or batch file.`)
 
 
    :::::::::::::::::::::::::

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -7,7 +7,7 @@ Before joining the workshop or following the lesson, please complete the data an
 
 ## Data
 
-The example images used in this lesson are available on [FigShare](https://figshare.com/).
+The example images and a description of the Python environment used in this lesson are available on [FigShare](https://figshare.com/).
 To download the data, please visit [the dataset page for this workshop][figshare-data]
 and click the "Download all" button.
 Unzip the downloaded file, and save the contents as a folder  called `data` somewhere you will easily find it again,
@@ -18,26 +18,20 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 
 1. Download and install the latest [MiniForge distribution of Python](https://conda-forge.org/download/) for your operating system. 
    Make sure to choose the Python 3 version (as opposed to the one with Python 2). 
-   If you wish to use an existing installation, be sure to upgrade your scikit-image to at least 0.19.
-   You can upgrade to the latest scikit-image using the shell command that follows.
+   If you already have a Python 3 setup that you are happy with, you can continue to use that (we recommend that you make sure your Python version is current).
+   The next step assumes that `conda` is available to manage your Python environment.
+2. Setup an environment to work in during the lesson.
+   In a terminal or the MiniForge Prompt application, navigate to the location where you saved the unzipped data for the lesson and run the following command:
 
-   :::::::::::::::::::::::::::::::::::::::::  callout
-
-   ## Updating scikit-image in an existing MiniForge distribution
-
-   ```shell
-   conda upgrade -y scikit-image
+   ```bash
+   conda env create -f environment.yml
    ```
 
-   ::::::::::::::::::::::::::::::::::::::::::::::::::
+   If prompted, allow `conda` to install the required libraries.
+3. Activate the new environment you just created:
 
-2. This lesson uses Matplotlib features to display images, and some
-   interactive features will be valuable. To enable the interactive
-   tools in JupyterLab, the `ipympl` package is required. The package
-   can be installed with the command
-
-   ```shell
-   conda install -c conda-forge ipympl
+   ```bash
+   conda activate dc-image
    ```
 
    :::::::::::::::::::::::::::::::::::::::::  callout

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -17,6 +17,7 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 ## Software
 
 1. Download and install the latest [Miniforge distribution of Python](https://conda-forge.org/download/) for your operating system. 
+   ([See more detailed instructions from The Carpentries](https://carpentries.github.io/workshop-template/#python-1).)
    If you already have a Python 3 setup that you are happy with, you can continue to use that (we recommend that you make sure your Python version is current).
    The next step assumes that `conda` is available to manage your Python environment.
 2. Set up an environment to work in during the lesson.

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -16,16 +16,14 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 
 ## Software
 
-1. Download and install the latest [Anaconda
-   distribution](https://www.anaconda.com/download/) for your
-   operating system. Make sure to choose the Python 3 version (as
-   opposed to the one with Python 2). If you wish to use an existing
-   installation, be sure to upgrade your scikit-image to at least 0.19.
+1. Download and install the latest [MiniForge distribution of Python](https://conda-forge.org/download/) for your operating system. 
+   Make sure to choose the Python 3 version (as opposed to the one with Python 2). 
+   If you wish to use an existing installation, be sure to upgrade your scikit-image to at least 0.19.
    You can upgrade to the latest scikit-image using the shell command that follows.
 
    :::::::::::::::::::::::::::::::::::::::::  callout
 
-   ## Updating scikit-image in an existing Anaconda distribution
+   ## Updating scikit-image in an existing MiniForge distribution
 
    ```shell
    conda upgrade -y scikit-image
@@ -83,7 +81,7 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 
    ## Instructions for Windows
 
-   Launch the Anaconda Prompt program and type `jupyter lab`.
+   Launch the MiniForge Prompt program and type `jupyter lab`.
    (Running this command on the standard Command Prompt will return an error:
    `'conda' is not recognized as an internal or external command, operable program or batch file.`)
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -10,16 +10,16 @@ Before joining the workshop or following the lesson, please complete the data an
 The example images and a description of the Python environment used in this lesson are available on [FigShare](https://figshare.com/).
 To download the data, please visit [the dataset page for this workshop][figshare-data]
 and click the "Download all" button.
-Unzip the downloaded file, and save the contents as a folder  called `data` somewhere you will easily find it again,
+Unzip the downloaded file, and save the contents as a folder called `data` somewhere you will easily find it again,
 e.g. your Desktop or a folder you have created for using in this workshop.
 (The name `data` is optional but recommended, as this is the name we will use to refer to the folder throughout the lesson.)
 
 ## Software
 
-1. Download and install the latest [MiniForge distribution of Python](https://conda-forge.org/download/) for your operating system. 
+1. Download and install the latest [Miniforge distribution of Python](https://conda-forge.org/download/) for your operating system. 
    If you already have a Python 3 setup that you are happy with, you can continue to use that (we recommend that you make sure your Python version is current).
    The next step assumes that `conda` is available to manage your Python environment.
-2. Setup an environment to work in during the lesson.
+2. Set up an environment to work in during the lesson.
    In a terminal (Linux/Mac) or the MiniForge Prompt application (Windows), navigate to the location where you saved the unzipped data for the lesson and run the following command:
 
    ```bash
@@ -74,7 +74,7 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 
    ## Instructions for Windows
 
-   Launch the MiniForge Prompt program and type `jupyter lab`.
+   Launch the Miniforge Prompt program and type `jupyter lab`.
    (Running this command on the standard Command Prompt will return an error:
    `'jupyter' is not recognized as an internal or external command, operable program or batch file.`)
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -17,7 +17,6 @@ e.g. your Desktop or a folder you have created for using in this workshop.
 ## Software
 
 1. Download and install the latest [MiniForge distribution of Python](https://conda-forge.org/download/) for your operating system. 
-   Make sure to choose the Python 3 version (as opposed to the one with Python 2). 
    If you already have a Python 3 setup that you are happy with, you can continue to use that (we recommend that you make sure your Python version is current).
    The next step assumes that `conda` is available to manage your Python environment.
 2. Setup an environment to work in during the lesson.


### PR DESCRIPTION
This updates the setup instructions for Python workshops. [A recent blog post provides more context for this change](https://carpentries.org/blog/2025/03/lesson-setup-instructions-task-force-recommendations/). Specifically, this PR updates the instructions to reflect that we recommend Miniforge instead of Anaconda Python. 

One of the most important changes here is to include an `environment.yml` for learners to use to create an environment that they can work in during the workshop/while following the lesson. When this PR is ready to merge, I will release a new version of the example data on FigShare that contains the environment file. Since I guess it will be helpful for testing purposes -- and because it is probably a good idea to keep a copy in the lesson repo too -- you can find my proposed version of that file in this PR.