### PR TITLE
Update maintainers in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ All participants should agree to abide by the [The Carpentries Code of Conduct](
 
 The Image Processing with Python lesson is currently being maintained by:
 
-- [Jacob Deppen](https://github.com/deppen8)
 - [Kimberly Meechan](https://github.com/K-Meech)
 - [Ulf Schiller](https://github.com/uschille)
+- [Marco Dalla Vecchia](https://github.com/marcodallavecchia)
 
 The lesson is built on content originally developed by [Mark Meysenburg](https://github.com/mmeysenburg), [Tessa Durham Brooks](https://github.com/tessalea), [Dominik Kutra](https://github.com/k-dominik), [Constantin Pape](https://github.com/constantinpape), and [Erin Becker](https://github.com/ebecker).


### PR DESCRIPTION
This PR updates the list of maintainers in the `README`, to match the current [maintainer team](https://github.com/orgs/datacarpentry/teams/image-processing-curriculum-maintainers).